### PR TITLE
Refactor palette dialog to reuse dictionary views

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -152,15 +152,16 @@
     <script src="js/components/mont-marte.js"></script>
     <!-- 分类管理组件 -->
     <script src="js/components/category-manager.js"></script>
-    <!-- 高级颜色选择对话框组件 -->
-    <script src="js/components/color-palette-dialog.js"></script>
     <!-- 自配色字典模块化依赖 -->
     <script src="js/components/color-dictionary/helpers.js"></script>
+    <script src="js/utils/color-processing.js"></script>
     <script src="js/components/color-dictionary/mixins/data.js"></script>
     <script src="js/components/color-dictionary/mixins/interactions.js"></script>
     <script src="js/components/color-dictionary/views/list-view.js"></script>
     <script src="js/components/color-dictionary/views/hsl-view.js"></script>
     <script src="js/components/color-dictionary/views/wheel-view.js"></script>
+    <!-- 高级颜色选择对话框组件 -->
+    <script src="js/components/color-palette-dialog.js"></script>
     <!-- 自配色字典页面组件 -->
     <script src="js/components/color-dictionary.js"></script>
     <!-- 计算器浮层组件 (步骤3) -->

--- a/frontend/js/components/color-dictionary/mixins/data.js
+++ b/frontend/js/components/color-dictionary/mixins/data.js
@@ -34,6 +34,20 @@
             },
 
             enrichColors() {
+                const utils = window.ColorProcessingUtils;
+                if (utils && typeof utils.enrichColors === 'function') {
+                    const fallback = (categoryId) => {
+                        if (utils && typeof utils.getDefaultColorForCategory === 'function') {
+                            return utils.getDefaultColorForCategory(categoryId);
+                        }
+                        return this.getDefaultColorForCategory(categoryId);
+                    };
+                    this.enrichedColors = utils.enrichColors(this.colors, {
+                        fallbackByCategory: fallback
+                    });
+                    return;
+                }
+
                 this.enrichedColors = this.colors.map((color) => {
                     const enriched = { ...color };
 

--- a/frontend/js/components/color-dictionary/views/hsl-view.js
+++ b/frontend/js/components/color-dictionary/views/hsl-view.js
@@ -4,15 +4,16 @@
     const helpers = window.ColorDictionaryHelpers || { getColorStyle: () => null };
 
     const HslDictionaryView = {
-    template: `
+        name: 'HslDictionaryView',
+        template: `
         <div class="hsl-color-space-view">
             <!-- Hue Slider -->
             <div class="hue-slider-container">
                 <div class="hue-controls">
-                    <label>色相 (Hue): {{ selectedHue }}°</label>
+                    <label>色相 (Hue): {{ Math.round(selectedHue) }}°</label>
                     <div class="hue-presets">
-                        <button 
-                            v-for="preset in huePresets" 
+                        <button
+                            v-for="preset in huePresets"
                             :key="preset.value"
                             @click="selectedHue = preset.value"
                             class="hue-preset-btn"
@@ -22,17 +23,17 @@
                         </button>
                     </div>
                 </div>
-                <input 
-                    type="range" 
+                <input
+                    type="range"
                     v-model="selectedHue"
-                    min="0" 
+                    min="0"
                     max="360"
                     class="hue-slider"
                     :style="hueSliderStyle"
                 >
             </div>
-            
-            <!-- Grid Size Control -->
+
+            <!-- Grid Size & Filters -->
             <div class="grid-controls">
                 <label>网格密度: </label>
                 <el-radio-group v-model="gridSize" size="small">
@@ -40,45 +41,61 @@
                     <el-radio-button :label="10">10x10</el-radio-button>
                     <el-radio-button :label="15">15x15</el-radio-button>
                 </el-radio-group>
-                <span class="grid-info" style="margin-left: 10px;">{{ colorsInHue.length }} 个颜色在此色相范围</span>
+                <el-checkbox
+                    v-if="showRgbToggle"
+                    v-model="showOnlyWithRGB"
+                    class="grid-control-checkbox"
+                >
+                    仅显示有RGB数据的颜色
+                </el-checkbox>
+                <div v-if="showHueToleranceControl" class="hue-tolerance-control">
+                    <span class="tolerance-label">色相容差: {{ effectiveHueTolerance }}°</span>
+                    <el-slider
+                        v-model="hueTolerance"
+                        :min="5"
+                        :max="30"
+                        :step="5"
+                        class="tolerance-slider"
+                        show-tooltip
+                    ></el-slider>
+                </div>
+                <span class="grid-info">{{ colorsInHue.length }} 个颜色在此色相范围</span>
             </div>
-            
+
             <!-- Saturation-Lightness Grid -->
             <div class="sl-grid-container">
                 <div class="sl-grid" :style="gridStyle">
-                    <div 
-                        v-for="(row, rowIndex) in colorGrid" 
+                    <div
+                        v-for="(row, rowIndex) in colorGrid"
                         :key="rowIndex"
                         class="grid-row"
                     >
-                        <div 
+                        <div
                             v-for="(cell, colIndex) in row"
                             :key="colIndex"
                             class="grid-cell"
                             :style="getCellStyle(cell)"
+                            @click="selectCell(cell)"
                             :title="getCellTooltip(cell)"
-                            :class="{ 
+                            :class="{
                                 'has-colors': cell.colors.length > 0
                             }"
                         >
-                            <!-- Individual color dots -->
-                            <div class="cell-dots-container">
-                                <div 
-                                    v-for="(color, idx) in cell.colors"
-                                    :key="color.id"
-                                    class="cell-color-dot"
-                                    :style="getDotStyle(color, idx, cell.colors.length)"
-                                    @click.stop="selectColor(color)"
-                                    :title="color.color_code + ' - ' + (color.color_name || '未命名')"
-                                    :class="{ 'selected': selectedColor && selectedColor.id === color.id }"
-                                >
-                                </div>
+                            <div
+                                v-for="(color, idx) in cell.colors"
+                                :key="color.id"
+                                class="cell-color-dot"
+                                :style="getDotStyle(color, idx, cell.colors.length)"
+                                :class="{ 'selected': isSelected(color) }"
+                                @click.stop="selectColor(color)"
+                                @mouseenter="$emit('hover', color)"
+                                @mouseleave="$emit('hover', null)"
+                            >
                             </div>
                         </div>
                     </div>
                 </div>
-                
-                <!-- Grid Labels -->
+
                 <div class="grid-labels">
                     <div class="label-y">
                         <span>明</span>
@@ -88,21 +105,23 @@
                     <div class="label-x">饱和度 →</div>
                 </div>
             </div>
-            
-            <!-- Color matches in current hue with fixed thumbnails -->
+
+            <!-- Color matches in current hue -->
             <div class="hue-colors" v-if="colorsInHue.length > 0">
                 <div class="hue-colors-header">
-                    <h4>当前色相范围的颜色 ({{ selectedHue - 15 }}° - {{ selectedHue + 15 }}°)</h4>
+                    <h4>当前色相范围的颜色 ({{ selectedHue - effectiveHueTolerance }}° - {{ selectedHue + effectiveHueTolerance }}°)</h4>
                 </div>
                 <div class="color-chips">
-                    <div 
+                    <div
                         v-for="color in colorsInHue"
                         :key="color.id"
                         class="color-chip-80"
                         @click="selectColor(color)"
                         :class="{ 'selected': isSelected(color) }"
+                        @mouseenter="$emit('hover', color)"
+                        @mouseleave="$emit('hover', null)"
                     >
-                        <div class="color-preview" 
+                        <div class="color-preview"
                              :class="{ 'blank-color': !getColorStyle(color) }"
                              :style="getColorStyle(color) ? { background: getColorStyle(color) } : {}">
                             <span v-if="!getColorStyle(color)" class="blank-text">无</span>
@@ -113,202 +132,242 @@
             </div>
         </div>
     `,
-    
-    props: {
-        colors: Array,
-        selectedColor: Object
-    },
-    
-    data() {
-        return {
-            selectedHue: 180,
-            gridSize: 10,
-            huePresets: [
-                { name: '红', value: 0 },
-                { name: '橙', value: 30 },
-                { name: '黄', value: 60 },
-                { name: '绿', value: 120 },
-                { name: '青', value: 180 },
-                { name: '蓝', value: 240 },
-                { name: '紫', value: 300 }
-            ]
-        };
-    },
-    
-    computed: {
-        hueSliderStyle() {
+
+        props: {
+            colors: {
+                type: Array,
+                default: () => []
+            },
+            selectedColor: {
+                type: Object,
+                default: null
+            },
+            showRgbToggle: {
+                type: Boolean,
+                default: false
+            },
+            initialShowRgbOnly: {
+                type: Boolean,
+                default: false
+            },
+            showHueToleranceControl: {
+                type: Boolean,
+                default: false
+            },
+            initialHueTolerance: {
+                type: Number,
+                default: 15
+            },
+            defaultGridSize: {
+                type: Number,
+                default: 10
+            }
+        },
+
+        data() {
             return {
-                background: `linear-gradient(to right, 
-                    hsl(0, 100%, 50%), 
-                    hsl(60, 100%, 50%), 
-                    hsl(120, 100%, 50%), 
-                    hsl(180, 100%, 50%), 
-                    hsl(240, 100%, 50%), 
-                    hsl(300, 100%, 50%), 
-                    hsl(360, 100%, 50%))`
+                selectedHue: 180,
+                gridSize: this.defaultGridSize,
+                hueTolerance: this.initialHueTolerance,
+                showOnlyWithRGB: this.showRgbToggle ? this.initialShowRgbOnly : false,
+                huePresets: [
+                    { name: '红', value: 0 },
+                    { name: '橙', value: 30 },
+                    { name: '黄', value: 60 },
+                    { name: '绿', value: 120 },
+                    { name: '青', value: 180 },
+                    { name: '蓝', value: 240 },
+                    { name: '紫', value: 300 }
+                ]
             };
         },
-        
-        gridStyle() {
-            // Ensure grid maintains fixed size with correct divisions
-            // Cells will automatically fill the space (1fr = equal fraction)
-            return {
-                gridTemplateColumns: `repeat(${this.gridSize}, 1fr)`,
-                gridTemplateRows: `repeat(${this.gridSize}, 1fr)`,
-                width: '520px',
-                height: '520px',
-                padding: '0',
-                gap: '0'
-            };
-        },
-        
-        colorGrid() {
-            const grid = [];
-            for (let l = 0; l < this.gridSize; l++) {
-                const row = [];
-                for (let s = 0; s < this.gridSize; s++) {
-                    const saturation = (s / (this.gridSize - 1)) * 100;
-                    const lightness = 100 - (l / (this.gridSize - 1)) * 100;
-                    
-                    // Find colors that match this cell
-                    const matchingColors = this.colorsInHue.filter(color => {
-                        if (!color.hsl) return false;
-                        const sDiff = Math.abs(color.hsl.s - saturation);
-                        const lDiff = Math.abs(color.hsl.l - lightness);
-                        return sDiff <= (100 / this.gridSize / 2) && lDiff <= (100 / this.gridSize / 2);
-                    });
-                    
-                    row.push({
-                        saturation,
-                        lightness,
-                        colors: matchingColors
-                    });
+
+        computed: {
+            hueSliderStyle() {
+                return {
+                    background: `linear-gradient(to right,
+                        hsl(0, 100%, 50%),
+                        hsl(60, 100%, 50%),
+                        hsl(120, 100%, 50%),
+                        hsl(180, 100%, 50%),
+                        hsl(240, 100%, 50%),
+                        hsl(300, 100%, 50%),
+                        hsl(360, 100%, 50%))`
+                };
+            },
+
+            gridStyle() {
+                return {
+                    gridTemplateColumns: `repeat(${this.gridSize}, 1fr)`,
+                    gridTemplateRows: `repeat(${this.gridSize}, 1fr)`,
+                    width: '520px',
+                    height: '520px',
+                    padding: '0',
+                    gap: '0'
+                };
+            },
+
+            effectiveHueTolerance() {
+                return this.showHueToleranceControl ? this.hueTolerance : 15;
+            },
+
+            filteredColors() {
+                const source = Array.isArray(this.colors) ? this.colors : [];
+                return source.filter((color) => {
+                    if (!color) return false;
+                    if (this.showRgbToggle && this.showOnlyWithRGB && !color.hasValidRGB) {
+                        return false;
+                    }
+                    if (!color.hsl || color.hsl.h === undefined) {
+                        return false;
+                    }
+                    const hueDiff = Math.abs(color.hsl.h - this.selectedHue);
+                    const inRange = Math.min(hueDiff, 360 - hueDiff) <= this.effectiveHueTolerance;
+                    return inRange;
+                });
+            },
+
+            colorGrid() {
+                const grid = [];
+                const colors = this.filteredColors;
+                const tolerance = this.gridSize <= 5 ? 20 : this.gridSize <= 10 ? 15 : 10;
+
+                for (let lIndex = 0; lIndex < this.gridSize; lIndex++) {
+                    const row = [];
+                    for (let sIndex = 0; sIndex < this.gridSize; sIndex++) {
+                        const saturation = (sIndex / (this.gridSize - 1)) * 100;
+                        const lightness = 100 - (lIndex / (this.gridSize - 1)) * 100;
+
+                        const matchingColors = colors.filter((color) => {
+                            if (!color.hsl) return false;
+                            const sDiff = Math.abs(color.hsl.s - saturation);
+                            const lDiff = Math.abs(color.hsl.l - lightness);
+                            return sDiff <= tolerance && lDiff <= tolerance;
+                        });
+
+                        row.push({
+                            saturation,
+                            lightness,
+                            colors: matchingColors
+                        });
+                    }
+                    grid.push(row);
                 }
-                grid.push(row);
+
+                return grid;
+            },
+
+            colorsInHue() {
+                return this.filteredColors;
             }
-            return grid;
         },
-        
-        colorsInHue() {
-            const tolerance = 15;
-            return this.colors.filter(color => {
-                if (!color.hsl || color.hsl.h === undefined) return false;
-                const hueDiff = Math.abs(color.hsl.h - this.selectedHue);
-                // Handle hue wrapping around 360
-                return Math.min(hueDiff, 360 - hueDiff) <= tolerance;
-            });
-        }
-    },
-    
-    methods: {
-        getCellStyle(cell) {
-            // Always show the HSL gradient background for the cell
-            const bgColor = `hsl(${this.selectedHue}, ${cell.saturation}%, ${cell.lightness}%)`;
-            
-            return {
-                background: bgColor,
-                // Cells now have consistent thin borders
-                width: '100%',
-                height: '100%',
-                display: 'block',
-                position: 'relative'
-            };
+
+        watch: {
+            selectedColor: {
+                immediate: true,
+                handler(newVal) {
+                    if (newVal && newVal.hsl && typeof newVal.hsl.h === 'number') {
+                        this.selectedHue = Math.round(newVal.hsl.h);
+                    }
+                }
+            }
         },
-        
-        getDotStyle(color, index, total) {
-            // Calculate dot position within the cell
-            const dotSize = this.calculateDotSize(total);
-            const position = this.calculateDotPosition(index, total, dotSize);
-            const bgColor = this.getColorStyle(color);
-            
-            return {
-                width: `${dotSize}px`,
-                height: `${dotSize}px`,
-                background: bgColor || '#f5f5f5',
-                border: bgColor ? '2px solid white' : '2px dashed #999',
-                position: 'absolute',
-                left: `${position.x}px`,
-                top: `${position.y}px`,
-                borderRadius: '50%',
-                cursor: 'pointer',
-                zIndex: 1
-            };
-        },
-        
-        calculateDotSize(total) {
-            // Calculate appropriate dot size based on grid size and number of colors
-            const cellSize = 520 / this.gridSize; // Size of each cell
-            
-            if (total === 1) {
-                return Math.min(30, cellSize * 0.6);
-            } else if (total <= 4) {
-                return Math.min(20, cellSize * 0.4);
-            } else {
+
+        methods: {
+            getCellStyle(cell) {
+                const bgColor = `hsl(${this.selectedHue}, ${cell.saturation}%, ${cell.lightness}%)`;
+                return {
+                    background: bgColor,
+                    width: '100%',
+                    height: '100%',
+                    display: 'block',
+                    position: 'relative'
+                };
+            },
+
+            getDotStyle(color, index, total) {
+                const cellSize = 520 / this.gridSize;
+                const dotSize = this.calculateDotSize(total, cellSize);
+                const position = this.calculateDotPosition(index, total, dotSize, cellSize);
+                const bgColor = this.getColorStyle(color);
+
+                return {
+                    width: `${dotSize}px`,
+                    height: `${dotSize}px`,
+                    background: bgColor || '#f5f5f5',
+                    border: bgColor ? '2px solid white' : '2px dashed #999',
+                    position: 'absolute',
+                    left: `${position.x}px`,
+                    top: `${position.y}px`,
+                    borderRadius: '50%',
+                    cursor: 'pointer',
+                    zIndex: 1
+                };
+            },
+
+            calculateDotSize(total, cellSize) {
+                if (total === 1) {
+                    return Math.min(30, cellSize * 0.6);
+                }
+                if (total <= 4) {
+                    return Math.min(20, cellSize * 0.4);
+                }
                 return Math.min(15, cellSize * 0.3);
-            }
-        },
-        
-        calculateDotPosition(index, total, dotSize) {
-            const cellSize = 520 / this.gridSize;
-            const centerX = cellSize / 2;
-            const centerY = cellSize / 2;
-            
-            if (total === 1) {
-                // Center single dot
-                return {
-                    x: centerX - dotSize / 2,
-                    y: centerY - dotSize / 2
-                };
-            } else if (total <= 4) {
-                // Arrange in 2x2 grid
-                const row = Math.floor(index / 2);
-                const col = index % 2;
-                const spacing = cellSize * 0.25;
-                return {
-                    x: centerX - dotSize + col * (dotSize + spacing/2),
-                    y: centerY - dotSize + row * (dotSize + spacing/2)
-                };
-            } else {
-                // Arrange in circular pattern
+            },
+
+            calculateDotPosition(index, total, dotSize, cellSize) {
+                const centerX = cellSize / 2;
+                const centerY = cellSize / 2;
+
+                if (total === 1) {
+                    return {
+                        x: centerX - dotSize / 2,
+                        y: centerY - dotSize / 2
+                    };
+                }
+                if (total <= 4) {
+                    const row = Math.floor(index / 2);
+                    const col = index % 2;
+                    const spacing = cellSize * 0.25;
+                    return {
+                        x: centerX - dotSize + col * (dotSize + spacing / 2),
+                        y: centerY - dotSize + row * (dotSize + spacing / 2)
+                    };
+                }
+
                 const angle = (index / total) * Math.PI * 2;
                 const radius = Math.min(20, cellSize * 0.3);
                 return {
                     x: centerX + Math.cos(angle) * radius - dotSize / 2,
                     y: centerY + Math.sin(angle) * radius - dotSize / 2
                 };
-            }
-        },
-        
-        getCellTooltip(cell) {
-            if (cell.colors.length === 0) {
-                return `S: ${Math.round(cell.saturation)}%, L: ${Math.round(cell.lightness)}%`;
-            }
-            return cell.colors.map(c => c.color_code).join(', ');
-        },
-        
-        selectCell(cell) {
-            if (cell.colors.length === 1) {
-                this.selectColor(cell.colors[0]);
-            } else if (cell.colors.length > 1) {
-                // If multiple colors, select the first one
-                this.selectColor(cell.colors[0]);
-            }
-        },
-        
-        selectColor(color) {
-            this.$emit('select', color);
-        },
-        
-        isSelected(color) {
-            return this.selectedColor && this.selectedColor.id === color.id;
-        },
-        
-        getColorStyle(color) {
-            return helpers.getColorStyle(color);
-        }
-    }
-};
+            },
 
+            getCellTooltip(cell) {
+                if (cell.colors.length === 0) {
+                    return `S: ${Math.round(cell.saturation)}%, L: ${Math.round(cell.lightness)}%`;
+                }
+                return cell.colors.map(c => c.color_code).join(', ');
+            },
+
+            selectCell(cell) {
+                if (cell.colors.length === 0) return;
+                this.selectColor(cell.colors[0]);
+            },
+
+            selectColor(color) {
+                this.$emit('select', color);
+            },
+
+            isSelected(color) {
+                return this.selectedColor && this.selectedColor.id === color.id;
+            },
+
+            getColorStyle(color) {
+                return helpers.getColorStyle(color);
+            }
+        }
+    };
 
     window.ColorDictionaryViews = window.ColorDictionaryViews || {};
     window.ColorDictionaryViews.HslDictionaryView = HslDictionaryView;

--- a/frontend/js/components/color-dictionary/views/list-view.js
+++ b/frontend/js/components/color-dictionary/views/list-view.js
@@ -2,11 +2,51 @@
     'use strict';
 
     const helpers = window.ColorDictionaryHelpers || { getColorStyle: () => null };
+    const processing = window.ColorProcessingUtils || {};
 
     const SimplifiedListView = {
+        name: 'SimplifiedListView',
         template: `
-        <div class="simplified-list-view">
-            <div class="category-list-container">
+        <div class="simplified-list-view" :class="{ 'is-advanced': enableAdvancedControls }">
+            <div v-if="enableAdvancedControls" class="list-controls">
+                <div class="control-row">
+                    <el-select v-model="sortBy" placeholder="排序方式" @change="handleSortChange">
+                        <el-option label="按色相" value="hue"></el-option>
+                        <el-option label="按明度" value="lightness"></el-option>
+                        <el-option label="按饱和度" value="saturation"></el-option>
+                        <el-option label="按名称" value="name"></el-option>
+                        <el-option label="按时间" value="date"></el-option>
+                    </el-select>
+                    <el-select v-model="filterCategory" placeholder="筛选分类" clearable @change="handleFilterChange">
+                        <el-option
+                            v-for="cat in categories"
+                            :key="cat.id"
+                            :label="cat.name"
+                            :value="cat.id"
+                        ></el-option>
+                    </el-select>
+                    <el-checkbox v-if="showRgbFilter" v-model="showOnlyWithRGB" @change="handleFilterChange">
+                        仅显示有RGB数据
+                    </el-checkbox>
+                </div>
+                <div v-if="showSearch" class="search-row">
+                    <el-input
+                        v-model="searchTerm"
+                        placeholder="搜索颜色编码或配方"
+                        clearable
+                        @input="handleSearch"
+                    >
+                        <template #prefix>
+                            <i class="el-icon-search"></i>
+                        </template>
+                    </el-input>
+                </div>
+                <div class="stats-row">
+                    显示 {{ filteredColors.length }} / {{ colors.length }} 个颜色
+                </div>
+            </div>
+
+            <div v-if="viewMode === 'categories'" class="category-list-container">
                 <div v-for="category in categories" :key="category.id" class="category-row">
                     <div class="category-label">{{ category.name }}</div>
                     <div class="category-colors">
@@ -51,6 +91,103 @@
                     </div>
                 </div>
             </div>
+
+            <div v-else class="color-list-container">
+                <div class="view-toggle">
+                    <el-radio-group v-model="viewMode" size="small">
+                        <el-radio-button label="grid">网格</el-radio-button>
+                        <el-radio-button label="list">列表</el-radio-button>
+                        <el-radio-button label="compact">紧凑</el-radio-button>
+                    </el-radio-group>
+                </div>
+
+                <div v-if="viewMode === 'grid'" class="color-grid">
+                    <div
+                        v-for="color in paginatedColors"
+                        :key="color.id"
+                        class="color-grid-item"
+                        :class="{
+                            'selected': color.id === selectedColorId,
+                            'has-rgb': color.hasValidRGB
+                        }"
+                        @click="handleSelect(color)"
+                        @mouseenter="handleHover(color)"
+                        @mouseleave="handleHoverEnd"
+                    >
+                        <div class="color-preview" :style="{ backgroundColor: getColorStyle(color) || getCategoryColor(color) }">
+                            <div v-if="showRgbFilter && !color.hasValidRGB" class="no-rgb-indicator">?</div>
+                        </div>
+                        <div class="color-label">{{ color.color_code }}</div>
+                        <div class="color-hsl" v-if="color.hsl">
+                            H:{{ Math.round(color.hsl.h) }}° S:{{ Math.round(color.hsl.s) }}%
+                        </div>
+                    </div>
+                </div>
+
+                <div v-else-if="viewMode === 'list'" class="color-list">
+                    <div
+                        v-for="color in paginatedColors"
+                        :key="color.id"
+                        class="color-list-item"
+                        :class="{ 'selected': color.id === selectedColorId }"
+                        @click="handleSelect(color)"
+                        @mouseenter="handleHover(color)"
+                        @mouseleave="handleHoverEnd"
+                    >
+                        <div class="color-swatch" :style="{ backgroundColor: getColorStyle(color) || getCategoryColor(color) }"></div>
+                        <div class="color-info">
+                            <div class="color-header">
+                                <span class="color-code">{{ color.color_code }}</span>
+                                <span class="color-category">{{ getCategoryName(color.category_id) }}</span>
+                            </div>
+                            <div class="color-formula">{{ color.formula || '未填写配方' }}</div>
+                            <div class="color-values" v-if="color.hasValidRGB">
+                                <span v-if="color.rgb">RGB: {{ color.rgb.r }}, {{ color.rgb.g }}, {{ color.rgb.b }}</span>
+                                <span v-if="color.hsl">HSL: {{ Math.round(color.hsl.h) }}°, {{ Math.round(color.hsl.s) }}%, {{ Math.round(color.hsl.l) }}%</span>
+                            </div>
+                        </div>
+                        <div class="color-wheel-position" v-if="color.hsl">
+                            <svg width="30" height="30" viewBox="0 0 30 30">
+                                <circle cx="15" cy="15" r="14" fill="none" stroke="#ddd" stroke-width="1"/>
+                                <circle
+                                    :cx="15 + 12 * Math.cos(color.hsl.h * Math.PI / 180) * (color.hsl.s / 100)"
+                                    :cy="15 + 12 * Math.sin(color.hsl.h * Math.PI / 180) * (color.hsl.s / 100)"
+                                    r="3"
+                                    :fill="getColorStyle(color) || '#888'"
+                                />
+                            </svg>
+                        </div>
+                    </div>
+                </div>
+
+                <div v-else class="color-compact">
+                    <span
+                        v-for="color in paginatedColors"
+                        :key="color.id"
+                        class="color-chip"
+                        :class="{ 'selected': color.id === selectedColorId }"
+                        @click="handleSelect(color)"
+                        @mouseenter="handleHover(color)"
+                        @mouseleave="handleHoverEnd"
+                        :style="{ backgroundColor: getColorStyle(color) || getCategoryColor(color) }"
+                    >
+                        {{ color.color_code }}
+                    </span>
+                </div>
+
+                <div class="pagination-controls" v-if="totalPages > 1">
+                    <el-pagination
+                        background
+                        layout="prev, pager, next, sizes"
+                        :page-size="pageSize"
+                        :current-page="currentPage"
+                        :total="filteredColors.length"
+                        :page-sizes="pageSizeOptions"
+                        @current-change="handlePageChange"
+                        @size-change="handleSizeChange"
+                    />
+                </div>
+            </div>
         </div>
     `,
 
@@ -70,28 +207,132 @@
             sortMode: {
                 type: String,
                 default: 'name'
+            },
+            enableAdvancedControls: {
+                type: Boolean,
+                default: false
+            },
+            defaultViewMode: {
+                type: String,
+                default: 'categories'
+            },
+            showRgbFilter: {
+                type: Boolean,
+                default: false
+            },
+            showSearch: {
+                type: Boolean,
+                default: false
+            },
+            pageSizeOptions: {
+                type: Array,
+                default: () => [24, 48, 96]
+            },
+            defaultPageSize: {
+                type: Number,
+                default: 24
+            }
+        },
+
+        data() {
+            return {
+                viewMode: this.enableAdvancedControls ? this.defaultViewMode : 'categories',
+                sortBy: 'hue',
+                filterCategory: null,
+                showOnlyWithRGB: false,
+                searchTerm: '',
+                currentPage: 1,
+                pageSize: this.defaultPageSize,
+                hoveredColor: null
+            };
+        },
+
+        computed: {
+            filteredColors() {
+                if (!this.enableAdvancedControls) {
+                    return [];
+                }
+
+                let filtered = Array.isArray(this.colors) ? [...this.colors] : [];
+
+                if (this.filterCategory) {
+                    filtered = filtered.filter(c => c.category_id === this.filterCategory);
+                }
+
+                if (this.showRgbFilter && this.showOnlyWithRGB) {
+                    filtered = filtered.filter(c => c.hasValidRGB);
+                }
+
+                if (this.searchTerm) {
+                    const term = this.searchTerm.toLowerCase();
+                    filtered = filtered.filter(c => {
+                        const code = (c.color_code || '').toLowerCase();
+                        const formula = (c.formula || '').toLowerCase();
+                        const name = (c.name || c.color_name || '').toLowerCase();
+                        return code.includes(term) || formula.includes(term) || name.includes(term);
+                    });
+                }
+
+                return this.sortAdvancedColors(filtered);
+            },
+
+            paginatedColors() {
+                if (!this.enableAdvancedControls) return [];
+                const start = (this.currentPage - 1) * this.pageSize;
+                const end = start + this.pageSize;
+                return this.filteredColors.slice(start, end);
+            },
+
+            totalPages() {
+                if (!this.enableAdvancedControls) return 0;
+                return Math.ceil(this.filteredColors.length / this.pageSize);
+            }
+        },
+
+        watch: {
+            selectedColorId(newVal) {
+                if (!this.enableAdvancedControls || !newVal) return;
+                const index = this.filteredColors.findIndex(c => c.id === newVal);
+                if (index >= 0) {
+                    const page = Math.floor(index / this.pageSize) + 1;
+                    if (page !== this.currentPage) {
+                        this.currentPage = page;
+                    }
+                }
+            },
+            enableAdvancedControls: {
+                immediate: true,
+                handler(value) {
+                    if (!value) {
+                        this.viewMode = 'categories';
+                    } else {
+                        this.viewMode = this.defaultViewMode;
+                    }
+                }
             }
         },
 
         methods: {
             getCategoryColors(categoryId) {
-                return this.colors.filter((c) => c.category_id === categoryId);
+                return (this.colors || []).filter((c) => c.category_id === categoryId);
             },
 
             getUncategorizedColors() {
-                const categoryIds = this.categories.map((c) => c.id);
-                return this.colors.filter((c) => !categoryIds.includes(c.category_id));
+                const categoryIds = (this.categories || []).map((c) => c.id);
+                return (this.colors || []).filter((c) => !categoryIds.includes(c.category_id));
             },
 
             getSortedCategoryColors(categoryId) {
-                return this.sortColors(this.getCategoryColors(categoryId));
+                const colors = this.getCategoryColors(categoryId);
+                return this.sortCategoryColors(colors);
             },
 
             getSortedUncategorizedColors() {
-                return this.sortColors(this.getUncategorizedColors());
+                const colors = this.getUncategorizedColors();
+                return this.sortCategoryColors(colors);
             },
 
-            sortColors(colors) {
+            sortCategoryColors(colors) {
                 if (this.sortMode === 'color') {
                     return [...colors].sort((a, b) => {
                         if (!a.hsl || !b.hsl) return 0;
@@ -114,6 +355,81 @@
                     }
                     return codeA.localeCompare(codeB, 'zh-CN');
                 });
+            },
+
+            sortAdvancedColors(colors) {
+                return [...colors].sort((a, b) => {
+                    switch (this.sortBy) {
+                        case 'hue':
+                            return (a.hsl?.h ?? 360) - (b.hsl?.h ?? 360);
+                        case 'lightness':
+                            return (a.hsl?.l ?? 0) - (b.hsl?.l ?? 0);
+                        case 'saturation':
+                            return (a.hsl?.s ?? 0) - (b.hsl?.s ?? 0);
+                        case 'date':
+                            return new Date(b.updated_at || 0) - new Date(a.updated_at || 0);
+                        case 'name':
+                        default:
+                            return (a.color_code || '').localeCompare(b.color_code || '');
+                    }
+                });
+            },
+
+            handleSelect(color) {
+                this.$emit('select', color);
+            },
+
+            handleHover(color) {
+                this.hoveredColor = color;
+                this.$emit('hover', color);
+            },
+
+            handleHoverEnd() {
+                this.hoveredColor = null;
+                this.$emit('hover', null);
+            },
+
+            handleSortChange() {
+                this.currentPage = 1;
+            },
+
+            handleFilterChange() {
+                this.currentPage = 1;
+            },
+
+            handleSearch() {
+                this.currentPage = 1;
+            },
+
+            handlePageChange(page) {
+                this.currentPage = page;
+            },
+
+            handleSizeChange(size) {
+                this.pageSize = size;
+                this.currentPage = 1;
+            },
+
+            getCategoryColor(color) {
+                if (processing && typeof processing.getDefaultColorForCategory === 'function') {
+                    const fallback = processing.getDefaultColorForCategory(color.category_id);
+                    return fallback ? `rgb(${fallback.r}, ${fallback.g}, ${fallback.b})` : '#CCCCCC';
+                }
+                const categoryColors = {
+                    1: '#4A90E2',
+                    2: '#F5D547',
+                    3: '#E85D75',
+                    4: '#7FBA40',
+                    5: '#9B59B6',
+                    6: '#FF6B6B',
+                    7: '#95A5A6'
+                };
+                return categoryColors[color.category_id] || '#CCCCCC';
+            },
+
+            getCategoryName(categoryId) {
+                const category = (this.categories || []).find(c => c.id === categoryId);
+                return category ? category.name : '';
             },
 
             getColorStyle(color) {

--- a/frontend/js/components/color-dictionary/views/wheel-view.js
+++ b/frontend/js/components/color-dictionary/views/wheel-view.js
@@ -2,14 +2,16 @@
     'use strict';
 
     const helpers = window.ColorDictionaryHelpers || { getColorStyle: () => null };
+    const processing = window.ColorProcessingUtils || {};
 
     const WheelDictionaryView = {
-    template: `
+        name: 'WheelDictionaryView',
+        template: `
         <div class="color-wheel-view">
             <div class="wheel-container" :class="{ 'dragging': isDragging }">
-                <canvas 
-                    ref="wheelCanvas" 
-                    width="600" 
+                <canvas
+                    ref="wheelCanvas"
+                    width="600"
                     height="600"
                     class="wheel-canvas"
                     @mousedown="handleMouseDown"
@@ -17,9 +19,8 @@
                     @mouseup="handleMouseUp"
                     @mouseleave="handleMouseLeave"
                 ></canvas>
-                <!-- Overlay color dots on the wheel -->
                 <div class="wheel-colors-overlay" :style="{ pointerEvents: isDragging ? 'none' : 'none' }">
-                    <div 
+                    <div
                         v-for="color in positionedColors"
                         :key="color.id"
                         class="wheel-color-dot"
@@ -29,19 +30,18 @@
                             background: getColorStyle(color) || 'transparent',
                             pointerEvents: isDragging ? 'none' : 'all'
                         }"
-                        :class="{ 
+                        :class="{
                             'selected': isSelected(color),
                             'blank': !getColorStyle(color),
                             'matched': isMatched(color)
                         }"
                         @click="selectColor(color)"
-                        :title="color.color_code + ' - ' + color.color_name"
+                        :title="color.color_code + ' - ' + (color.color_name || '')"
                     >
                         <span v-if="!getColorStyle(color)" class="blank-dot">×</span>
                     </div>
                 </div>
-                <!-- Click indicator -->
-                <div v-if="clickedPoint" 
+                <div v-if="clickedPoint"
                      class="click-indicator"
                      :class="{ 'dragging': isDragging }"
                      :style="{
@@ -53,14 +53,14 @@
             <div class="wheel-controls">
                 <div class="control-row">
                     <label>邻近范围 (ΔE): {{ proximityRange }}</label>
-                    <el-slider 
-                        v-model="proximityRange" 
-                        :min="0" 
+                    <el-slider
+                        v-model="proximityRange"
+                        :min="0"
                         :max="50"
                         :step="1"
                     ></el-slider>
                 </div>
-                <div class="control-row">
+                <div class="control-row" v-if="showRgbToggle">
                     <el-checkbox v-model="showOnlyWithRGB">
                         仅显示有RGB数据的颜色
                     </el-checkbox>
@@ -72,19 +72,18 @@
                     </span>
                 </div>
             </div>
-            
-            <!-- Matched colors section -->
+
             <div class="matched-colors-section" v-if="matchedColors.length > 0">
                 <h4>命中颜色 (ΔE ≤ {{ proximityRange }})</h4>
                 <div class="color-chips">
-                    <div 
+                    <div
                         v-for="color in matchedColors"
                         :key="color.id"
                         class="color-chip-80"
                         @click="selectColor(color)"
                         :class="{ 'selected': isSelected(color) }"
                     >
-                        <div class="color-preview" 
+                        <div class="color-preview"
                              :class="{ 'blank-color': !getColorStyle(color) }"
                              :style="getColorStyle(color) ? { background: getColorStyle(color) } : {}">
                             <span v-if="!getColorStyle(color)" class="blank-text">无</span>
@@ -96,326 +95,320 @@
             </div>
         </div>
     `,
-    
-    props: {
-        colors: Array,
-        selectedColor: Object
-    },
-    
-    data() {
-        return {
-            proximityRange: 15,
-            showOnlyWithRGB: false,
-            ctx: null,
-            centerX: 300,
-            centerY: 300,
-            radius: 270,
-            clickedPoint: null,
-            clickedColor: null,
-            matchedColors: [],
-            isDragging: false,
-            dragStart: null
-        };
-    },
-    
-    computed: {
-        visibleColors() {
-            let filtered = this.colors;
-            
-            if (this.showOnlyWithRGB) {
-                filtered = filtered.filter(c => 
-                    c.rgb_r != null && c.rgb_g != null && c.rgb_b != null
-                );
+
+        props: {
+            colors: {
+                type: Array,
+                default: () => []
+            },
+            selectedColor: {
+                type: Object,
+                default: null
+            },
+            showRgbToggle: {
+                type: Boolean,
+                default: true
+            },
+            initialShowRgbOnly: {
+                type: Boolean,
+                default: false
+            },
+            initialProximityRange: {
+                type: Number,
+                default: 15
+            },
+            deltaEAlgorithm: {
+                type: String,
+                default: '2000'
             }
-            
-            return filtered;
         },
-        
-        positionedColors() {
-            // Position colors on the wheel based on their HSL values
-            return this.visibleColors.map(color => {
-                if (!color.hsl || color.hsl.h === undefined) {
-                    // Place colors without HSL in the center
+
+        data() {
+            return {
+                proximityRange: this.initialProximityRange,
+                showOnlyWithRGB: this.showRgbToggle ? this.initialShowRgbOnly : false,
+                ctx: null,
+                centerX: 300,
+                centerY: 300,
+                radius: 270,
+                clickedPoint: null,
+                clickedColor: null,
+                matchedColors: [],
+                isDragging: false,
+                dragStart: null
+            };
+        },
+
+        computed: {
+            visibleColors() {
+                const source = Array.isArray(this.colors) ? this.colors : [];
+                if (this.showRgbToggle && this.showOnlyWithRGB) {
+                    return source.filter((c) => c && (c.hasValidRGB || (c.rgb_r != null && c.rgb_g != null && c.rgb_b != null)));
+                }
+                return source;
+            },
+
+            positionedColors() {
+                return this.visibleColors.map(color => {
+                    if (!color.hsl || color.hsl.h === undefined) {
+                        return {
+                            ...color,
+                            x: this.centerX + (Math.random() - 0.5) * 40,
+                            y: this.centerY + (Math.random() - 0.5) * 40
+                        };
+                    }
+
+                    const angle = (color.hsl.h * Math.PI) / 180;
+                    const distance = (color.hsl.s / 100) * this.radius * 0.9;
+
                     return {
                         ...color,
-                        x: this.centerX + (Math.random() - 0.5) * 40,
-                        y: this.centerY + (Math.random() - 0.5) * 40
+                        x: this.centerX + Math.cos(angle) * distance,
+                        y: this.centerY + Math.sin(angle) * distance
                     };
+                });
+            }
+        },
+
+        watch: {
+            proximityRange() {
+                if (this.clickedColor) {
+                    this.updateMatchedColors();
                 }
-                
-                // Calculate position based on hue and saturation
-                const angle = (color.hsl.h * Math.PI) / 180;
-                const distance = (color.hsl.s / 100) * this.radius * 0.9; // 90% of radius max
-                
-                return {
-                    ...color,
-                    x: this.centerX + Math.cos(angle) * distance,
-                    y: this.centerY + Math.sin(angle) * distance
-                };
+            }
+        },
+
+        mounted() {
+            this.$nextTick(() => {
+                this.initWheel();
             });
-        }
-    },
-    
-    watch: {
-        proximityRange() {
-            // Recalculate matched colors when range changes
-            if (this.clickedColor) {
-                this.updateMatchedColors();
-            }
-        }
-    },
-    
-    mounted() {
-        this.$nextTick(() => {
-            this.initWheel();
-        });
-    },
-    
-    methods: {
-        initWheel() {
-            this.wheelCanvas = this.$refs.wheelCanvas;
-            if (!this.wheelCanvas) return;
-            
-            this.ctx = this.wheelCanvas.getContext('2d');
-            this.drawWheelBackground();
         },
-        
-        drawWheelBackground() {
-            const ctx = this.ctx;
-            if (!ctx) return;
-            
-            // Clear canvas
-            ctx.clearRect(0, 0, 600, 600);
-            
-            // Draw color wheel gradient
-            for (let angle = 0; angle < 360; angle += 2) {
-                const startAngle = (angle - 1) * Math.PI / 180;
-                const endAngle = (angle + 1) * Math.PI / 180;
-                
-                // Create gradient from center to edge
-                const gradient = ctx.createRadialGradient(
-                    this.centerX, this.centerY, 0,
-                    this.centerX, this.centerY, this.radius
-                );
-                
-                // HSL color at this angle
-                gradient.addColorStop(0, `hsl(${angle}, 0%, 50%)`);
-                gradient.addColorStop(1, `hsl(${angle}, 100%, 50%)`);
-                
-                // Draw wedge
-                ctx.beginPath();
-                ctx.moveTo(this.centerX, this.centerY);
-                ctx.arc(this.centerX, this.centerY, this.radius, startAngle, endAngle);
-                ctx.closePath();
-                ctx.fillStyle = gradient;
-                ctx.fill();
-            }
-            
-            // Draw border
-            ctx.strokeStyle = '#ccc';
-            ctx.lineWidth = 2;
-            ctx.beginPath();
-            ctx.arc(this.centerX, this.centerY, this.radius, 0, 2 * Math.PI);
-            ctx.stroke();
-        },
-        
-        selectColor(color) {
-            this.$emit('select', color);
-        },
-        
-        isSelected(color) {
-            return this.selectedColor && this.selectedColor.id === color.id;
-        },
-        
-        getColorStyle(color) {
-            return helpers.getColorStyle(color);
-        },
-        
-        handleMouseDown(event) {
-            const rect = this.wheelCanvas.getBoundingClientRect();
-            // Calculate the scale factor between actual canvas size and CSS display size
-            const scaleX = this.wheelCanvas.width / rect.width;
-            const scaleY = this.wheelCanvas.height / rect.height;
-            
-            // Apply scale correction to get accurate canvas coordinates
-            const x = (event.clientX - rect.left) * scaleX;
-            const y = (event.clientY - rect.top) * scaleY;
-            
-            // Check if click is within the wheel
-            const dx = x - this.centerX;
-            const dy = y - this.centerY;
-            const distance = Math.sqrt(dx * dx + dy * dy);
-            
-            if (distance > this.radius) {
-                // Click outside the wheel
-                this.clickedPoint = null;
-                this.clickedColor = null;
-                this.matchedColors = [];
-                return;
-            }
-            
-            // Store clicked point and start dragging
-            this.clickedPoint = { x, y };
-            this.isDragging = true;
-            this.dragStart = { x: event.clientX, y: event.clientY };
-            
-            // Update color at this position
-            this.updateColorAtPosition(x, y);
-        },
-        
-        handleMouseMove(event) {
-            if (!this.isDragging || !this.clickedPoint) return;
-            
-            const rect = this.wheelCanvas.getBoundingClientRect();
-            const scaleX = this.wheelCanvas.width / rect.width;
-            const scaleY = this.wheelCanvas.height / rect.height;
-            
-            const x = (event.clientX - rect.left) * scaleX;
-            const y = (event.clientY - rect.top) * scaleY;
-            
-            // Check if new position is within the wheel
-            const dx = x - this.centerX;
-            const dy = y - this.centerY;
-            const distance = Math.sqrt(dx * dx + dy * dy);
-            
-            if (distance <= this.radius) {
-                // Update position
-                this.clickedPoint = { x, y };
-                
-                // Update color at new position
-                this.updateColorAtPosition(x, y);
-            }
-        },
-        
-        handleMouseUp(event) {
-            this.isDragging = false;
-            this.dragStart = null;
-        },
-        
-        handleMouseLeave(event) {
-            this.isDragging = false;
-            this.dragStart = null;
-        },
-        
-        updateColorAtPosition(x, y) {
-            // Calculate HSL from position
-            const dx = x - this.centerX;
-            const dy = y - this.centerY;
-            const distance = Math.sqrt(dx * dx + dy * dy);
-            
-            const angle = Math.atan2(dy, dx);
-            const hue = (angle * 180 / Math.PI + 360) % 360;
-            const saturation = (distance / this.radius) * 100;
-            const lightness = 50; // Fixed lightness for wheel
-            
-            // Create clicked color object
-            this.clickedColor = {
-                hsl: { h: hue, s: saturation, l: lightness },
-                hex: `hsl(${hue}, ${saturation}%, ${lightness}%)`
-            };
-            
-            // Convert to RGB for delta E calculation
-            const rgb = this.hslToRgb(hue / 360, saturation / 100, lightness / 100);
-            this.clickedColor.rgb_r = Math.round(rgb.r * 255);
-            this.clickedColor.rgb_g = Math.round(rgb.g * 255);
-            this.clickedColor.rgb_b = Math.round(rgb.b * 255);
-            
-            // Find matched colors
-            this.updateMatchedColors();
-            
-            // Draw click indicator
-            this.drawClickIndicator();
-        },
-        
-        updateMatchedColors() {
-            if (!this.clickedColor) {
-                this.matchedColors = [];
-                return;
-            }
-            
-            // Calculate delta E for all visible colors
-            const matched = [];
-            
-            for (const color of this.visibleColors) {
-                if (color.rgb_r != null && color.rgb_g != null && color.rgb_b != null) {
-                    const deltaE = this.calculateDeltaE(
-                        this.clickedColor,
-                        color
+
+        methods: {
+            initWheel() {
+                this.wheelCanvas = this.$refs.wheelCanvas;
+                if (!this.wheelCanvas) return;
+
+                this.ctx = this.wheelCanvas.getContext('2d');
+                this.drawWheelBackground();
+            },
+
+            drawWheelBackground() {
+                const ctx = this.ctx;
+                if (!ctx) return;
+
+                ctx.clearRect(0, 0, 600, 600);
+
+                for (let angle = 0; angle < 360; angle += 2) {
+                    const startAngle = (angle - 1) * Math.PI / 180;
+                    const endAngle = (angle + 1) * Math.PI / 180;
+
+                    const gradient = ctx.createRadialGradient(
+                        this.centerX, this.centerY, 0,
+                        this.centerX, this.centerY, this.radius
                     );
-                    
-                    if (deltaE <= this.proximityRange) {
+
+                    gradient.addColorStop(0, `hsl(${angle}, 0%, 50%)`);
+                    gradient.addColorStop(1, `hsl(${angle}, 100%, 50%)`);
+
+                    ctx.beginPath();
+                    ctx.moveTo(this.centerX, this.centerY);
+                    ctx.arc(this.centerX, this.centerY, this.radius, startAngle, endAngle);
+                    ctx.closePath();
+                    ctx.fillStyle = gradient;
+                    ctx.fill();
+                }
+
+                ctx.strokeStyle = '#ccc';
+                ctx.lineWidth = 2;
+                ctx.beginPath();
+                ctx.arc(this.centerX, this.centerY, this.radius, 0, 2 * Math.PI);
+                ctx.stroke();
+            },
+
+            selectColor(color) {
+                this.$emit('select', color);
+            },
+
+            isSelected(color) {
+                return this.selectedColor && this.selectedColor.id === color.id;
+            },
+
+            getColorStyle(color) {
+                return helpers.getColorStyle(color);
+            },
+
+            handleMouseDown(event) {
+                const rect = this.wheelCanvas.getBoundingClientRect();
+                const scaleX = this.wheelCanvas.width / rect.width;
+                const scaleY = this.wheelCanvas.height / rect.height;
+
+                const x = (event.clientX - rect.left) * scaleX;
+                const y = (event.clientY - rect.top) * scaleY;
+
+                const dx = x - this.centerX;
+                const dy = y - this.centerY;
+                const distance = Math.sqrt(dx * dx + dy * dy);
+
+                if (distance > this.radius) {
+                    this.clickedPoint = null;
+                    this.clickedColor = null;
+                    this.matchedColors = [];
+                    return;
+                }
+
+                this.clickedPoint = { x, y };
+                this.isDragging = true;
+                this.dragStart = { x: event.clientX, y: event.clientY };
+
+                this.updateColorAtPosition(x, y);
+            },
+
+            handleMouseMove(event) {
+                if (!this.isDragging || !this.clickedPoint) return;
+
+                const rect = this.wheelCanvas.getBoundingClientRect();
+                const scaleX = this.wheelCanvas.width / rect.width;
+                const scaleY = this.wheelCanvas.height / rect.height;
+
+                const x = (event.clientX - rect.left) * scaleX;
+                const y = (event.clientY - rect.top) * scaleY;
+
+                const dx = x - this.centerX;
+                const dy = y - this.centerY;
+                const distance = Math.sqrt(dx * dx + dy * dy);
+
+                if (distance <= this.radius) {
+                    this.clickedPoint = { x, y };
+                    this.updateColorAtPosition(x, y);
+                }
+            },
+
+            handleMouseUp() {
+                this.isDragging = false;
+                this.dragStart = null;
+            },
+
+            handleMouseLeave() {
+                this.isDragging = false;
+                this.dragStart = null;
+            },
+
+            updateColorAtPosition(x, y) {
+                const dx = x - this.centerX;
+                const dy = y - this.centerY;
+                const distance = Math.sqrt(dx * dx + dy * dy);
+
+                const angle = Math.atan2(dy, dx);
+                const hue = (angle * 180 / Math.PI + 360) % 360;
+                const saturation = (distance / this.radius) * 100;
+                const lightness = 50;
+
+                const rgb = typeof this.hslToRgb === 'function'
+                    ? this.hslToRgb(hue / 360, saturation / 100, lightness / 100)
+                    : this.hslToRgbLocal(hue / 360, saturation / 100, lightness / 100);
+
+                this.clickedColor = {
+                    hsl: { h: hue, s: saturation, l: lightness },
+                    rgb_r: Math.round(rgb.r * 255),
+                    rgb_g: Math.round(rgb.g * 255),
+                    rgb_b: Math.round(rgb.b * 255)
+                };
+
+                this.updateMatchedColors();
+                this.drawClickIndicator();
+            },
+
+            updateMatchedColors() {
+                if (!this.clickedColor) {
+                    this.matchedColors = [];
+                    return;
+                }
+
+                const algorithm = this.deltaEAlgorithm;
+                const matched = [];
+
+                for (const color of this.visibleColors) {
+                    if (!color) continue;
+                    const deltaE = this.calculateDeltaE(this.clickedColor, color, algorithm);
+                    if (Number.isFinite(deltaE) && deltaE <= this.proximityRange) {
                         matched.push({
                             ...color,
-                            deltaE: deltaE
+                            deltaE
                         });
                     }
                 }
-            }
-            
-            // Sort by delta E
-            matched.sort((a, b) => a.deltaE - b.deltaE);
-            
-            this.matchedColors = matched;
-        },
-        
-        isMatched(color) {
-            return this.matchedColors.some(m => m.id === color.id);
-        },
-        
-        calculateDeltaE(color1, color2) {
-            // Using CIE76 formula for simplicity
-            // Convert RGB to LAB would be more accurate but this is sufficient
-            const r1 = color1.rgb_r || 0;
-            const g1 = color1.rgb_g || 0;
-            const b1 = color1.rgb_b || 0;
-            
-            const r2 = color2.rgb_r || 0;
-            const g2 = color2.rgb_g || 0;
-            const b2 = color2.rgb_b || 0;
-            
-            // Simple Euclidean distance in RGB space
-            // Scale to approximate delta E range (0-100)
-            const dr = r1 - r2;
-            const dg = g1 - g2;
-            const db = b1 - b2;
-            
-            return Math.sqrt(dr * dr + dg * dg + db * db) * 0.4;
-        },
-        
-        hslToRgb(h, s, l) {
-            let r, g, b;
-            
-            if (s === 0) {
-                r = g = b = l; // achromatic
-            } else {
-                const hue2rgb = (p, q, t) => {
-                    if (t < 0) t += 1;
-                    if (t > 1) t -= 1;
-                    if (t < 1/6) return p + (q - p) * 6 * t;
-                    if (t < 1/2) return q;
-                    if (t < 2/3) return p + (q - p) * (2/3 - t) * 6;
-                    return p;
-                };
-                
-                const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
-                const p = 2 * l - q;
-                r = hue2rgb(p, q, h + 1/3);
-                g = hue2rgb(p, q, h);
-                b = hue2rgb(p, q, h - 1/3);
-            }
-            
-            return { r, g, b };
-        },
-        
-        drawClickIndicator() {
-            // Remove canvas drawing - we're using the div indicator instead
-            // Just redraw the wheel background to clear any previous canvas marks
-            if (this.ctx) {
-                this.drawWheelBackground();
+
+                matched.sort((a, b) => a.deltaE - b.deltaE);
+                this.matchedColors = matched;
+            },
+
+            isMatched(color) {
+                return this.matchedColors.some(m => m.id === color.id);
+            },
+
+            calculateDeltaE(color1, color2, algorithm) {
+                if (processing && typeof processing.calculateDeltaE === 'function') {
+                    return processing.calculateDeltaE(color1, color2, { algorithm });
+                }
+                return this.calculateDeltaEFallback(color1, color2);
+            },
+
+            calculateDeltaEFallback(color1, color2) {
+                const r1 = color1.rgb_r || 0;
+                const g1 = color1.rgb_g || 0;
+                const b1 = color1.rgb_b || 0;
+                const r2 = color2.rgb_r || 0;
+                const g2 = color2.rgb_g || 0;
+                const b2 = color2.rgb_b || 0;
+                const dr = r1 - r2;
+                const dg = g1 - g2;
+                const db = b1 - b2;
+                return Math.sqrt(dr * dr + dg * dg + db * db) * 0.4;
+            },
+
+            hslToRgbLocal(h, s, l) {
+                let r, g, b;
+                if (s === 0) {
+                    r = g = b = l;
+                } else {
+                    const hue2rgb = (p, q, t) => {
+                        if (t < 0) t += 1;
+                        if (t > 1) t -= 1;
+                        if (t < 1/6) return p + (q - p) * 6 * t;
+                        if (t < 1/2) return q;
+                        if (t < 2/3) return p + (q - p) * (2/3 - t) * 6;
+                        return p;
+                    };
+
+                    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+                    const p = 2 * l - q;
+                    r = hue2rgb(p, q, h + 1/3);
+                    g = hue2rgb(p, q, h);
+                    b = hue2rgb(p, q, h - 1/3);
+                }
+                return { r, g, b };
+            },
+
+            hslToRgb(h, s, l) {
+                if (typeof window.hslToRgb === 'function') {
+                    const value = window.hslToRgb(h * 360, s * 100, l * 100);
+                    return {
+                        r: value.r / 255,
+                        g: value.g / 255,
+                        b: value.b / 255
+                    };
+                }
+                return this.hslToRgbLocal(h, s, l);
+            },
+
+            drawClickIndicator() {
+                if (this.ctx) {
+                    this.drawWheelBackground();
+                }
             }
         }
-    }
-};
+    };
 
     window.ColorDictionaryViews = window.ColorDictionaryViews || {};
     window.ColorDictionaryViews.WheelDictionaryView = WheelDictionaryView;

--- a/frontend/js/components/color-palette-dialog.js
+++ b/frontend/js/components/color-palette-dialog.js
@@ -3,6 +3,12 @@
  * Advanced color selection dialog with HSL and Color Wheel views
  */
 
+const paletteDebug = (...args) => {
+    if (typeof window !== 'undefined' && window.__DEBUG__) {
+        console.log(...args);
+    }
+};
+
 // Forward declare the component, we'll add child components later
 const ColorPaletteDialog = {
     template: `
@@ -98,6 +104,11 @@ const ColorPaletteDialog = {
                     v-if="activeTab === 'hsl'"
                     :colors="enrichedColors"
                     :selected-color="selectedColor"
+                    :show-rgb-toggle="true"
+                    :show-hue-tolerance-control="true"
+                    :initial-hue-tolerance="viewPreferences.hueTolerance"
+                    :initial-show-rgb-only="viewPreferences.onlyShowRgb"
+                    :default-grid-size="viewPreferences.hslGridSize"
                     @select="handleColorSelect"
                     @hover="handleColorHover"
                 />
@@ -106,6 +117,10 @@ const ColorPaletteDialog = {
                     v-if="activeTab === 'wheel'"
                     :colors="enrichedColors"
                     :selected-color="selectedColor"
+                    :show-rgb-toggle="true"
+                    :initial-show-rgb-only="viewPreferences.onlyShowRgb"
+                    :initial-proximity-range="viewPreferences.wheelProximity"
+                    :delta-e-algorithm="'2000'"
                     @select="handleColorSelect"
                     @hover="handleColorHover"
                 />
@@ -113,8 +128,14 @@ const ColorPaletteDialog = {
                 <enhanced-list-view
                     v-if="activeTab === 'list'"
                     :colors="enrichedColors"
-                    :selected-color="selectedColor"
                     :categories="categories"
+                    :selected-color-id="selectedColor ? selectedColor.id : null"
+                    :enable-advanced-controls="true"
+                    :default-view-mode="viewPreferences.listViewMode"
+                    :show-rgb-filter="true"
+                    :show-search="true"
+                    :default-page-size="viewPreferences.listPageSize"
+                    :sort-mode="viewPreferences.categorySort"
                     @select="handleColorSelect"
                     @hover="handleColorHover"
                 />
@@ -195,25 +216,16 @@ const ColorPaletteDialog = {
             enrichedColors: [],
             isMobile: window.innerWidth < 768,
             showHelp: false,
-            colorState: {
-                selectedHue: 180,
-                proximityRange: 15,
-                sortBy: 'hue',
-                filterCategory: null
+            viewPreferences: {
+                hslGridSize: 10,
+                hueTolerance: 15,
+                onlyShowRgb: false,
+                wheelProximity: 15,
+                listViewMode: 'grid',
+                listPageSize: 24,
+                categorySort: 'name'
             }
         };
-    },
-    
-    computed: {
-        // Provide shared state to child components
-        sharedState() {
-            return {
-                colors: this.enrichedColors,
-                selectedColor: this.selectedColor,
-                hoveredColor: this.hoveredColor,
-                colorState: this.colorState
-            };
-        }
     },
     
     watch: {
@@ -239,13 +251,13 @@ const ColorPaletteDialog = {
     },
     
     created() {
-        console.log('ColorPaletteDialog created');
-        console.log('Initial visible:', this.visible);
-        console.log('Initial colors:', this.colors?.length);
+        paletteDebug('ColorPaletteDialog created');
+        paletteDebug('Initial visible:', this.visible);
+        paletteDebug('Initial colors:', this.colors?.length);
     },
     
     mounted() {
-        console.log('ColorPaletteDialog mounted');
+        paletteDebug('ColorPaletteDialog mounted');
         if (this.colors && this.colors.length > 0) {
             this.enrichColors();
         }
@@ -268,101 +280,87 @@ const ColorPaletteDialog = {
     methods: {
         // Enrich colors with calculated properties
         enrichColors() {
-            console.log('Starting enrichColors with', this.colors?.length, 'colors');
-            
-            // Check if colors exist
-            if (!this.colors || this.colors.length === 0) {
+            const utils = window.ColorProcessingUtils;
+            paletteDebug('Enriching palette colors', this.colors ? this.colors.length : 0);
+
+            if (!Array.isArray(this.colors) || this.colors.length === 0) {
                 this.enrichedColors = [];
                 return;
             }
-            
-            // Process all colors synchronously
+
+            if (utils && typeof utils.enrichColors === 'function') {
+                const fallback = (categoryId) => {
+                    if (utils && typeof utils.getDefaultColorForCategory === 'function') {
+                        return utils.getDefaultColorForCategory(categoryId);
+                    }
+                    return null;
+                };
+
+                this.enrichedColors = utils.enrichColors(this.colors, {
+                    fallbackByCategory: fallback
+                });
+                return;
+            }
+
+            const categoryColors = {
+                1: { r: 70, g: 130, b: 180 },
+                2: { r: 255, g: 215, b: 0 },
+                3: { r: 220, g: 20, b: 60 },
+                4: { r: 34, g: 139, b: 34 },
+                5: { r: 128, g: 0, b: 128 },
+                6: { r: 139, g: 69, b: 19 },
+                7: { r: 255, g: 140, b: 0 }
+            };
+
             this.enrichedColors = this.colors.map((color, index) => {
                 const enriched = { ...color };
-                
+
                 try {
-                    // Try to get RGB from different sources
-                    let rgb = null;
-                    let hasValidRGB = false;
-                    
-                    // Check for hex value (database field: hex_color)
-                    if (color.hex_color && color.hex_color !== '未填写' && color.hex_color !== '') {
-                        const hex = color.hex_color.startsWith('#') ? color.hex_color : '#' + color.hex_color;
-                        rgb = hexToRgb(hex);
-                        enriched.hex = hex;
-                        hasValidRGB = true;
-                    }
-                    // Check for RGB values (database fields: rgb_r, rgb_g, rgb_b)
-                    else if (color.rgb_r !== null && color.rgb_r !== undefined && 
-                             color.rgb_g !== null && color.rgb_g !== undefined && 
-                             color.rgb_b !== null && color.rgb_b !== undefined) {
-                        rgb = {
-                            r: parseInt(color.rgb_r) || 0,
-                            g: parseInt(color.rgb_g) || 0,
-                            b: parseInt(color.rgb_b) || 0
-                        };
-                        enriched.hex = rgbToHex(rgb.r, rgb.g, rgb.b);
-                        hasValidRGB = true;
-                    }
-                    // Use category default color if no RGB data
-                    else {
-                        rgb = this.getDefaultColorForCategory(color.category_id);
-                        enriched.hex = rgbToHex(rgb.r, rgb.g, rgb.b);
-                        hasValidRGB = false;
-                    }
-                    
-                    // Mark whether this color has valid RGB data
-                    enriched.hasValidRGB = hasValidRGB;
-                    
-                    enriched.rgb = rgb;
-                    
-                    // Calculate HSL and LAB
-                    if (rgb && typeof rgbToHsl !== 'undefined') {
-                        enriched.hsl = rgbToHsl(rgb.r, rgb.g, rgb.b);
+                    const hasHex = color.hex_color && color.hex_color !== '未填写';
+                    const normalizedHex = hasHex
+                        ? (color.hex_color.startsWith('#') ? color.hex_color : `#${color.hex_color}`)
+                        : null;
+
+                    if (normalizedHex && typeof hexToRgb === 'function') {
+                        const rgb = hexToRgb(normalizedHex);
+                        enriched.rgb = rgb;
+                        enriched.hex = normalizedHex;
+                        enriched.hsl = typeof rgbToHsl === 'function' ? rgbToHsl(rgb.r, rgb.g, rgb.b) : null;
+                        enriched.lab = typeof rgbToLab === 'function' ? rgbToLab(rgb.r, rgb.g, rgb.b) : null;
+                        enriched.hasValidRGB = true;
+                    } else if (color.rgb_r != null && color.rgb_g != null && color.rgb_b != null) {
+                        const r = parseInt(color.rgb_r, 10) || 0;
+                        const g = parseInt(color.rgb_g, 10) || 0;
+                        const b = parseInt(color.rgb_b, 10) || 0;
+                        enriched.rgb = { r, g, b };
+                        enriched.hex = typeof rgbToHex === 'function' ? rgbToHex(r, g, b) : null;
+                        enriched.hsl = typeof rgbToHsl === 'function' ? rgbToHsl(r, g, b) : null;
+                        enriched.lab = typeof rgbToLab === 'function' ? rgbToLab(r, g, b) : null;
+                        enriched.hasValidRGB = true;
                     } else {
-                        enriched.hsl = { h: 0, s: 0, l: 50 };
+                        const fallbackColor = categoryColors[color.category_id] || { r: 128, g: 128, b: 128 };
+                        enriched.rgb = fallbackColor;
+                        enriched.hex = typeof rgbToHex === 'function' ? rgbToHex(fallbackColor.r, fallbackColor.g, fallbackColor.b) : '#808080';
+                        enriched.hsl = typeof rgbToHsl === 'function' ? rgbToHsl(fallbackColor.r, fallbackColor.g, fallbackColor.b) : null;
+                        enriched.lab = typeof rgbToLab === 'function' ? rgbToLab(fallbackColor.r, fallbackColor.g, fallbackColor.b) : null;
+                        enriched.hasValidRGB = false;
                     }
-                    
-                    if (rgb && typeof rgbToLab !== 'undefined') {
-                        enriched.lab = rgbToLab(rgb.r, rgb.g, rgb.b);
-                    } else {
-                        enriched.lab = { L: 50, a: 0, b: 0 };
-                    }
-                    
-                    // Ensure the color has a name property for consistency
-                    // Database returns color_code, not color_name
+
                     if (!enriched.name) {
                         enriched.name = color.color_code || color.color_name || `Color ${index + 1}`;
                     }
-                    
-                    // Log first few colors for debugging
-                    if (index < 3) {
-                        console.log(`Color ${index}: ${enriched.name}`, {
-                            original: { 
-                                hex_color: color.hex_color, 
-                                rgb_r: color.rgb_r,
-                                rgb_g: color.rgb_g,
-                                rgb_b: color.rgb_b,
-                                hasValidRGB: hasValidRGB
-                            },
-                            enriched: { hex: enriched.hex, rgb: enriched.rgb, hsl: enriched.hsl }
-                        });
-                    }
                 } catch (error) {
                     console.error('Error enriching color:', error);
-                    // Fallback values on any error
                     enriched.rgb = { r: 128, g: 128, b: 128 };
                     enriched.hsl = { h: 0, s: 0, l: 50 };
                     enriched.lab = { L: 50, a: 0, b: 0 };
                     enriched.hex = '#808080';
+                    enriched.hasValidRGB = false;
                 }
-                
+
                 return enriched;
             });
-            
-            console.log('Total enriched colors:', this.enrichedColors.length);
         },
-        
         // Extract dominant color from image
         async extractColorFromImage(imagePath) {
             return new Promise((resolve) => {
@@ -488,27 +486,27 @@ const ColorPaletteDialog = {
             }
         },
         
-        // Get default color based on category
-        getDefaultColorForCategory(categoryId) {
-            // Default colors for different categories
-            const categoryColors = {
-                1: { r: 70, g: 130, b: 180 },  // 蓝 - Blue
-                2: { r: 255, g: 215, b: 0 },   // 黄 - Yellow
-                3: { r: 220, g: 20, b: 60 },   // 红 - Red
-                4: { r: 34, g: 139, b: 34 },   // 绿 - Green
-                5: { r: 128, g: 0, b: 128 },   // 紫 - Purple
-                6: { r: 139, g: 69, b: 19 },   // 色精 - Brown
-                7: { r: 255, g: 140, b: 0 }    // 其他 - Orange
-            };
-            
-            return categoryColors[categoryId] || { r: 128, g: 128, b: 128 };
-        },
-        
         // Get color style for preview
         getColorStyle(color) {
-            if (color.hex) return color.hex;
+            if (!color) {
+                return '#808080';
+            }
+            const helpers = window.ColorDictionaryHelpers || {};
+            if (helpers.getColorStyle) {
+                const style = helpers.getColorStyle(color);
+                if (style) {
+                    return style;
+                }
+            }
+            if (color.hex) {
+                return color.hex;
+            }
             if (color.rgb) {
                 return `rgb(${color.rgb.r}, ${color.rgb.g}, ${color.rgb.b})`;
+            }
+            if (color.hex_color) {
+                const hex = color.hex_color.startsWith('#') ? color.hex_color : `#${color.hex_color}`;
+                return hex;
             }
             return '#808080';
         },
@@ -533,1012 +531,25 @@ const ColorPaletteDialog = {
     }
 };
 
-// HSL Color Space View Component - Enhanced
-const HslColorSpaceView = {
-    template: `
-        <div class="hsl-color-space-view">
-            <!-- Hue Slider -->
-            <div class="hue-slider-container">
-                <div class="hue-controls">
-                    <label>色相 (Hue): {{ selectedHue }}°</label>
-                    <div class="hue-presets">
-                        <button 
-                            v-for="preset in huePresets" 
-                            :key="preset.value"
-                            @click="selectedHue = preset.value"
-                            class="hue-preset-btn"
-                            :style="{ backgroundColor: 'hsl(' + preset.value + ', 100%, 50%)' }"
-                            :title="preset.name"
-                        >
-                        </button>
-                    </div>
-                </div>
-                <input 
-                    type="range" 
-                    v-model="selectedHue"
-                    min="0" 
-                    max="360"
-                    class="hue-slider"
-                    :style="hueSliderStyle"
-                >
-            </div>
-            
-            <!-- Grid Size Control -->
-            <div class="grid-controls">
-                <label>网格密度: </label>
-                <el-radio-group v-model="gridSize" size="small">
-                    <el-radio-button :label="5">5x5</el-radio-button>
-                    <el-radio-button :label="10">10x10</el-radio-button>
-                    <el-radio-button :label="15">15x15</el-radio-button>
-                </el-radio-group>
-                <el-checkbox v-model="showOnlyWithRGB" style="margin-left: 10px;">
-                    仅显示有RGB数据的颜色
-                </el-checkbox>
-                <span class="grid-info">{{ matchedColorsCount }} 个颜色在此色相范围</span>
-            </div>
-            
-            <!-- Saturation-Lightness Grid -->
-            <div class="sl-grid-container">
-                <div class="sl-grid" :style="gridStyle">
-                    <div 
-                        v-for="(row, rowIndex) in colorGrid" 
-                        :key="rowIndex"
-                        class="grid-row"
-                    >
-                        <div 
-                            v-for="(cell, colIndex) in row"
-                            :key="colIndex"
-                            class="grid-cell"
-                            :style="getCellStyle(cell)"
-                            @click="selectCell(cell)"
-                            @mouseenter="hoverCell(cell)"
-                            @mouseleave="hoveredCell = null"
-                            :title="getCellTooltip(cell)"
-                            :class="{ 
-                                'has-colors': cell.colors.length > 0,
-                                'is-hovered': hoveredCell === cell
-                            }"
-                        >
-                            <!-- Color count indicator -->
-                            <div v-if="cell.colors.length > 1" class="color-count">
-                                {{ cell.colors.length }}
-                            </div>
-                            
-                            <!-- Show dots for actual colors -->
-                            <div 
-                                v-for="(color, idx) in cell.colors.slice(0, 4)"
-                                :key="color.id"
-                                class="color-dot"
-                                :class="{ 
-                                    'selected': isSelected(color),
-                                    'mini': cell.colors.length > 2
-                                }"
-                                :style="getDotPosition(idx, cell.colors.length)"
-                                @click.stop="selectColor(color)"
-                            />
-                        </div>
-                    </div>
-                </div>
-                
-                <!-- Grid Labels -->
-                <div class="grid-labels">
-                    <div class="label-y">
-                        <span>明</span>
-                        <span>度</span>
-                        <span>↓</span>
-                    </div>
-                    <div class="label-x">饱和度 →</div>
-                </div>
-            </div>
-            
-            <!-- Color matches in current hue -->
-            <div class="hue-colors" v-if="colorsInHue.length > 0">
-                <div class="hue-colors-header">
-                    <h4>当前色相范围的颜色 ({{ selectedHue - hueTolerance }}° - {{ selectedHue + hueTolerance }}°)</h4>
-                    <el-slider 
-                        v-model="hueTolerance" 
-                        :min="5" 
-                        :max="30" 
-                        :step="5"
-                        size="small"
-                        style="width: 150px; margin-left: 20px;"
-                    />
-                </div>
-                <div class="color-chips">
-                    <div 
-                        v-for="color in colorsInHue"
-                        :key="color.id"
-                        class="color-chip"
-                        :style="{ backgroundColor: color.hex }"
-                        @click="selectColor(color)"
-                        @mouseenter="$emit('hover', color)"
-                        :title="color.name + ' - ' + color.formula"
-                        :class="{ 'selected': isSelected(color) }"
-                    >
-                        <span class="chip-name">{{ color.color_code }}</span>
-                    </div>
-                </div>
-            </div>
-        </div>
-    `,
-    
-    props: {
-        colors: Array,
-        selectedColor: Object
-    },
-    
-    data() {
-        return {
-            selectedHue: 180,
-            colorGrid: [],
-            hoveredCell: null,
-            gridSize: 10,
-            hueTolerance: 15,
-            showOnlyWithRGB: false,
-            huePresets: [
-                { name: '红', value: 0 },
-                { name: '橙', value: 30 },
-                { name: '黄', value: 60 },
-                { name: '绿', value: 120 },
-                { name: '青', value: 180 },
-                { name: '蓝', value: 240 },
-                { name: '紫', value: 270 },
-                { name: '品红', value: 300 }
-            ]
-        };
-    },
-    
-    computed: {
-        hueSliderStyle() {
-            if (typeof createHueGradient !== 'undefined') {
-                return { background: createHueGradient() };
-            }
-            return {
-                background: `linear-gradient(to right, 
-                    hsl(0, 100%, 50%), 
-                    hsl(60, 100%, 50%), 
-                    hsl(120, 100%, 50%), 
-                    hsl(180, 100%, 50%), 
-                    hsl(240, 100%, 50%), 
-                    hsl(300, 100%, 50%), 
-                    hsl(360, 100%, 50%))`
-            };
-        },
-        
-        gridStyle() {
-            // Return empty since we're using flexbox for rows, not CSS grid
-            return {};
-        },
-        
-        colorsInHue() {
-            if (!this.colors || this.colors.length === 0) {
-                console.log('No colors available for filtering');
-                return [];
-            }
-            
-            const filtered = [];
-            for (const color of this.colors) {
-                // Filter out colors without valid RGB data if the option is enabled
-                if (this.showOnlyWithRGB && !color.hasValidRGB) {
-                    continue;
-                }
-                
-                if (!color.hsl) {
-                    if (filtered.length === 0) {
-                        console.log('Color has no HSL:', color);
-                    }
-                    continue;
-                }
-                const hueDiff = Math.abs(color.hsl.h - this.selectedHue);
-                const minDiff = Math.min(hueDiff, 360 - hueDiff);
-                const inRange = minDiff <= this.hueTolerance;
-                if (inRange) {
-                    filtered.push(color);
-                    if (filtered.length <= 3) {
-                        console.log(`Color ${color.name || color.color_code} in range: hue=${color.hsl.h}, diff=${minDiff}, hasRGB=${color.hasValidRGB}`);
-                    }
-                }
-            }
-            
-            return filtered.sort((a, b) => {
-                // Sort by saturation and lightness
-                const aDist = Math.abs(a.hsl.s - 50) + Math.abs(a.hsl.l - 50);
-                const bDist = Math.abs(b.hsl.s - 50) + Math.abs(b.hsl.l - 50);
-                return aDist - bDist;
-            });
-        },
-        
-        matchedColorsCount() {
-            return this.colorsInHue.length;
-        }
-    },
-    
-    watch: {
-        selectedHue() {
-            this.generateGrid();
-        },
-        gridSize() {
-            this.generateGrid();
-        },
-        hueTolerance() {
-            // Just trigger computed update, no need to regenerate grid
-        }
-    },
-    
-    mounted() {
-        console.log('HSL view mounted, generating grid');
-        console.log('Colors received in HSL view:', this.colors?.length);
-        console.log('First 3 colors:', this.colors?.slice(0, 3).map(c => ({
-            name: c.name || c.color_name,
-            hsl: c.hsl,
-            hex: c.hex
-        })));
-        console.log('Hue tolerance:', this.hueTolerance);
-        console.log('Selected hue:', this.selectedHue);
-        this.generateGrid();
-        if (this.selectedColor && this.selectedColor.hsl) {
-            this.selectedHue = this.selectedColor.hsl.h;
-        }
-    },
-    
-    methods: {
-        generateGrid() {
-            console.log('generateGrid called, gridSize:', this.gridSize);
-            const grid = [];
-            const step = 100 / this.gridSize;
-            
-            for (let l = 100; l >= 0; l -= step) {
-                const row = [];
-                for (let s = 0; s <= 100; s += step) {
-                    const cellHsl = { 
-                        h: this.selectedHue, 
-                        s: Math.round(s), 
-                        l: Math.round(l) 
-                    };
-                    const cellRgb = typeof hslToRgb !== 'undefined' 
-                        ? hslToRgb(this.selectedHue, s, l)
-                        : { r: 128, g: 128, b: 128 };
-                    
-                    // Find colors that match this cell
-                    const matchingColors = this.findMatchingColors(cellHsl);
-                    
-                    row.push({
-                        hsl: cellHsl,
-                        rgb: cellRgb,
-                        hex: typeof rgbToHex !== 'undefined'
-                            ? rgbToHex(cellRgb.r, cellRgb.g, cellRgb.b)
-                            : '#808080',
-                        colors: matchingColors
-                    });
-                }
-                grid.push(row);
-            }
-            
-            this.colorGrid = grid;
-            console.log('Grid generated, rows:', grid.length, 'first row cells:', grid[0]?.length);
-        },
-        
-        findMatchingColors(targetHsl) {
-            // Dynamic tolerance based on grid size
-            const tolerance = {
-                h: this.hueTolerance,
-                s: this.gridSize <= 5 ? 20 : this.gridSize <= 10 ? 15 : 10,
-                l: this.gridSize <= 5 ? 20 : this.gridSize <= 10 ? 15 : 10
-            };
-            
-            return this.colors.filter(color => {
-                if (!color.hsl) return false;
-                
-                const hDiff = Math.abs(color.hsl.h - targetHsl.h);
-                const sDiff = Math.abs(color.hsl.s - targetHsl.s);
-                const lDiff = Math.abs(color.hsl.l - targetHsl.l);
-                
-                return Math.min(hDiff, 360 - hDiff) <= tolerance.h &&
-                       sDiff <= tolerance.s &&
-                       lDiff <= tolerance.l;
-            });
-        },
-        
-        getCellStyle(cell) {
-            return {
-                backgroundColor: cell.hex,
-                border: this.hoveredCell === cell ? '2px solid #fff' : 'none'
-            };
-        },
-        
-        getCellTooltip(cell) {
-            const tooltip = `HSL: ${cell.hsl.h}°, ${cell.hsl.s}%, ${cell.hsl.l}%`;
-            if (cell.colors.length > 0) {
-                const names = cell.colors.map(c => c.name).join(', ');
-                return `${tooltip}\n颜色: ${names}`;
-            }
-            return tooltip;
-        },
-        
-        selectCell(cell) {
-            if (cell.colors.length === 1) {
-                this.selectColor(cell.colors[0]);
-            } else if (cell.colors.length > 1) {
-                // Show selection if multiple colors
-                this.$message.info(`此位置有 ${cell.colors.length} 个颜色`);
-            }
-        },
-        
-        hoverCell(cell) {
-            this.hoveredCell = cell;
-            if (cell.colors.length === 1) {
-                this.$emit('hover', cell.colors[0]);
-            }
-        },
-        
-        selectColor(color) {
-            this.$emit('select', color);
-        },
-        
-        isSelected(color) {
-            return this.selectedColor && this.selectedColor.id === color.id;
-        },
-        
-        getDotPosition(index, total) {
-            // Position dots in a grid pattern within the cell
-            if (total === 1) {
-                return {}; // Center
-            }
-            if (total === 2) {
-                return {
-                    left: index === 0 ? '25%' : '75%',
-                    top: '50%',
-                    transform: 'translate(-50%, -50%)'
-                };
-            }
-            if (total <= 4) {
-                const positions = [
-                    { left: '25%', top: '25%' },
-                    { left: '75%', top: '25%' },
-                    { left: '25%', top: '75%' },
-                    { left: '75%', top: '75%' }
-                ];
-                return {
-                    ...positions[index],
-                    transform: 'translate(-50%, -50%)'
-                };
-            }
-            return {}; // Default center for more than 4
-        }
-    }
-};
+const dictionaryViews = window.ColorDictionaryViews || {};
+const paletteComponents = {};
 
-// Color Wheel View Component (placeholder)
-const ColorWheelView = {
-    template: `
-        <div class="color-wheel-view">
-            <div class="wheel-container">
-                <canvas 
-                    ref="wheelCanvas" 
-                    width="600" 
-                    height="600"
-                    @click="handleCanvasClick"
-                    @mousemove="handleCanvasHover"
-                ></canvas>
-            </div>
-            <div class="wheel-controls">
-                <div class="control-row">
-                    <label>邻近范围 (ΔE): {{ proximityRange }}</label>
-                    <el-slider 
-                        v-model="proximityRange" 
-                        :min="0" 
-                        :max="50"
-                        :step="1"
-                        @change="updateWheel"
-                    ></el-slider>
-                </div>
-                <div class="control-row">
-                    <el-checkbox v-model="showOnlyWithRGB" @change="updateWheel">
-                        仅显示有RGB数据的颜色
-                    </el-checkbox>
-                </div>
-                <div class="stats">
-                    显示 {{ visibleColors.length }} / {{ filteredColors.length }} 个颜色
-                </div>
-            </div>
-            <div class="selected-colors" v-if="nearbyColors.length > 0">
-                <h4>邻近颜色 (ΔE ≤ {{ proximityRange }})</h4>
-                <div class="color-chips">
-                    <span 
-                        v-for="color in nearbyColors" 
-                        :key="color.id"
-                        class="color-chip"
-                        :style="{ backgroundColor: color.hex }"
-                        @click="$emit('select', color)"
-                        :title="color.color_code"
-                    >
-                        {{ color.color_code }}
-                    </span>
-                </div>
-            </div>
-        </div>
-    `,
-    props: {
-        colors: Array,
-        selectedColor: Object
-    },
-    data() {
-        return {
-            proximityRange: 15,
-            wheelCanvas: null,
-            ctx: null,
-            centerX: 300,
-            centerY: 300,
-            radius: 280,
-            showOnlyWithRGB: false,
-            hoveredColor: null,
-            nearbyColors: [],
-            colorPositions: [] // Store color positions for click detection
-        };
-    },
-    computed: {
-        filteredColors() {
-            if (this.showOnlyWithRGB) {
-                return this.colors.filter(c => c.hasValidRGB);
-            }
-            return this.colors;
-        },
-        visibleColors() {
-            // Colors visible based on proximity filter
-            if (!this.selectedColor || this.proximityRange === 50) {
-                return this.filteredColors;
-            }
-            
-            return this.filteredColors.filter(color => {
-                const deltaE = this.calculateDeltaE(this.selectedColor, color);
-                return deltaE <= this.proximityRange;
-            });
-        }
-    },
-    mounted() {
-        this.wheelCanvas = this.$refs.wheelCanvas;
-        this.ctx = this.wheelCanvas.getContext('2d');
-        this.initWheel();
-    },
-    watch: {
-        colors() {
-            this.updateWheel();
-        },
-        selectedColor() {
-            this.updateWheel();
-            this.updateNearbyColors();
-        }
-    },
-    methods: {
-        initWheel() {
-            this.drawWheelBackground();
-            this.plotColors();
-        },
-        
-        drawWheelBackground() {
-            const ctx = this.ctx;
-            ctx.clearRect(0, 0, 600, 600);
-            
-            // Draw the color wheel background
-            const imageData = ctx.createImageData(600, 600);
-            const data = imageData.data;
-            
-            for (let x = 0; x < 600; x++) {
-                for (let y = 0; y < 600; y++) {
-                    const dx = x - this.centerX;
-                    const dy = y - this.centerY;
-                    const distance = Math.sqrt(dx * dx + dy * dy);
-                    
-                    if (distance <= this.radius) {
-                        // Calculate hue from angle
-                        let angle = Math.atan2(dy, dx) * 180 / Math.PI;
-                        if (angle < 0) angle += 360;
-                        
-                        // Calculate saturation from distance
-                        const saturation = (distance / this.radius) * 100;
-                        
-                        // Fixed lightness at 50% for wheel
-                        const lightness = 50;
-                        
-                        // Convert HSL to RGB
-                        const rgb = this.hslToRgb(angle, saturation, lightness);
-                        
-                        const index = (y * 600 + x) * 4;
-                        data[index] = rgb.r;
-                        data[index + 1] = rgb.g;
-                        data[index + 2] = rgb.b;
-                        data[index + 3] = 255;
-                    }
-                }
-            }
-            
-            ctx.putImageData(imageData, 0, 0);
-            
-            // Draw border
-            ctx.strokeStyle = '#ccc';
-            ctx.lineWidth = 2;
-            ctx.beginPath();
-            ctx.arc(this.centerX, this.centerY, this.radius, 0, 2 * Math.PI);
-            ctx.stroke();
-        },
-        
-        plotColors() {
-            const ctx = this.ctx;
-            this.colorPositions = [];
-            
-            // Plot each color as a dot
-            this.visibleColors.forEach(color => {
-                if (!color.hsl) return;
-                
-                const pos = this.mapColorToWheel(color.hsl);
-                this.colorPositions.push({
-                    color: color,
-                    x: pos.x,
-                    y: pos.y,
-                    size: pos.size
-                });
-                
-                // Draw outer white ring
-                ctx.beginPath();
-                ctx.arc(pos.x, pos.y, pos.size + 2, 0, 2 * Math.PI);
-                ctx.fillStyle = '#fff';
-                ctx.fill();
-                ctx.strokeStyle = '#333';
-                ctx.lineWidth = 1;
-                ctx.stroke();
-                
-                // Draw inner color circle
-                ctx.beginPath();
-                ctx.arc(pos.x, pos.y, pos.size, 0, 2 * Math.PI);
-                ctx.fillStyle = color.hex || '#888';
-                ctx.fill();
-                
-                // Highlight selected color
-                if (this.selectedColor && this.selectedColor.id === color.id) {
-                    ctx.strokeStyle = '#ff0000';
-                    ctx.lineWidth = 3;
-                    ctx.beginPath();
-                    ctx.arc(pos.x, pos.y, pos.size + 4, 0, 2 * Math.PI);
-                    ctx.stroke();
-                }
-            });
-        },
-        
-        mapColorToWheel(hsl) {
-            // Map HSL to wheel position
-            const angle = hsl.h * Math.PI / 180;
-            const distance = (hsl.s / 100) * this.radius * 0.9; // 0.9 to keep dots inside
-            
-            const x = this.centerX + distance * Math.cos(angle);
-            const y = this.centerY + distance * Math.sin(angle);
-            
-            // Size based on lightness (darker = smaller, lighter = larger)
-            const size = 3 + (hsl.l / 100) * 5;
-            
-            return { x, y, size };
-        },
-        
-        hslToRgb(h, s, l) {
-            s /= 100;
-            l /= 100;
-            
-            const c = (1 - Math.abs(2 * l - 1)) * s;
-            const x = c * (1 - Math.abs((h / 60) % 2 - 1));
-            const m = l - c / 2;
-            
-            let r = 0, g = 0, b = 0;
-            
-            if (h >= 0 && h < 60) {
-                r = c; g = x; b = 0;
-            } else if (h >= 60 && h < 120) {
-                r = x; g = c; b = 0;
-            } else if (h >= 120 && h < 180) {
-                r = 0; g = c; b = x;
-            } else if (h >= 180 && h < 240) {
-                r = 0; g = x; b = c;
-            } else if (h >= 240 && h < 300) {
-                r = x; g = 0; b = c;
-            } else if (h >= 300 && h < 360) {
-                r = c; g = 0; b = x;
-            }
-            
-            return {
-                r: Math.round((r + m) * 255),
-                g: Math.round((g + m) * 255),
-                b: Math.round((b + m) * 255)
-            };
-        },
-        
-        calculateDeltaE(color1, color2) {
-            if (!color1.lab || !color2.lab) {
-                // Fallback to simple RGB distance if LAB not available
-                if (!color1.rgb || !color2.rgb) return 100;
-                
-                const dr = color1.rgb.r - color2.rgb.r;
-                const dg = color1.rgb.g - color2.rgb.g;
-                const db = color1.rgb.b - color2.rgb.b;
-                return Math.sqrt(dr * dr + dg * dg + db * db) / 4.41; // Normalize to roughly 0-100
-            }
-            
-            // Simple CIE76 Delta E calculation
-            const dL = color1.lab.L - color2.lab.L;
-            const da = color1.lab.a - color2.lab.a;
-            const db = color1.lab.b - color2.lab.b;
-            
-            return Math.sqrt(dL * dL + da * da + db * db);
-        },
-        
-        handleCanvasClick(event) {
-            const rect = this.wheelCanvas.getBoundingClientRect();
-            const x = event.clientX - rect.left;
-            const y = event.clientY - rect.top;
-            
-            // Find clicked color
-            let minDistance = Infinity;
-            let clickedColor = null;
-            
-            this.colorPositions.forEach(pos => {
-                const distance = Math.sqrt(
-                    Math.pow(x - pos.x, 2) + 
-                    Math.pow(y - pos.y, 2)
-                );
-                
-                if (distance < pos.size + 5 && distance < minDistance) {
-                    minDistance = distance;
-                    clickedColor = pos.color;
-                }
-            });
-            
-            if (clickedColor) {
-                this.$emit('select', clickedColor);
-            }
-        },
-        
-        handleCanvasHover(event) {
-            const rect = this.wheelCanvas.getBoundingClientRect();
-            const x = event.clientX - rect.left;
-            const y = event.clientY - rect.top;
-            
-            // Find hovered color
-            let hoveredColor = null;
-            
-            this.colorPositions.forEach(pos => {
-                const distance = Math.sqrt(
-                    Math.pow(x - pos.x, 2) + 
-                    Math.pow(y - pos.y, 2)
-                );
-                
-                if (distance < pos.size + 5) {
-                    hoveredColor = pos.color;
-                }
-            });
-            
-            if (hoveredColor !== this.hoveredColor) {
-                this.hoveredColor = hoveredColor;
-                if (hoveredColor) {
-                    this.$emit('hover', hoveredColor);
-                    this.wheelCanvas.style.cursor = 'pointer';
-                } else {
-                    this.wheelCanvas.style.cursor = 'default';
-                }
-            }
-        },
-        
-        updateWheel() {
-            this.drawWheelBackground();
-            this.plotColors();
-        },
-        
-        updateNearbyColors() {
-            if (!this.selectedColor) {
-                this.nearbyColors = [];
-                return;
-            }
-            
-            this.nearbyColors = this.filteredColors
-                .filter(color => {
-                    if (color.id === this.selectedColor.id) return false;
-                    const deltaE = this.calculateDeltaE(this.selectedColor, color);
-                    return deltaE <= this.proximityRange;
-                })
-                .sort((a, b) => {
-                    const deltaA = this.calculateDeltaE(this.selectedColor, a);
-                    const deltaB = this.calculateDeltaE(this.selectedColor, b);
-                    return deltaA - deltaB;
-                })
-                .slice(0, 12); // Show max 12 nearby colors
-        }
-    }
-};
+if (dictionaryViews.HslDictionaryView) {
+    paletteComponents['hsl-color-space-view'] = dictionaryViews.HslDictionaryView;
+} else {
+    paletteDebug('HSL view module unavailable for palette dialog');
+}
 
-// Enhanced List View Component with full features
-const EnhancedListView = {
-    template: `
-        <div class="enhanced-list-view">
-            <div class="list-controls">
-                <div class="control-row">
-                    <el-select v-model="sortBy" placeholder="排序方式" @change="handleSortChange">
-                        <el-option label="按色相" value="hue"></el-option>
-                        <el-option label="按明度" value="lightness"></el-option>
-                        <el-option label="按饱和度" value="saturation"></el-option>
-                        <el-option label="按名称" value="name"></el-option>
-                        <el-option label="按时间" value="date"></el-option>
-                    </el-select>
-                    <el-select v-model="filterCategory" placeholder="筛选分类" clearable @change="handleFilterChange">
-                        <el-option 
-                            v-for="cat in categories" 
-                            :key="cat.id"
-                            :label="cat.name" 
-                            :value="cat.id"
-                        ></el-option>
-                    </el-select>
-                    <el-checkbox v-model="showOnlyWithRGB" @change="handleFilterChange">
-                        仅显示有RGB数据
-                    </el-checkbox>
-                </div>
-                <div class="search-row">
-                    <el-input 
-                        v-model="searchTerm" 
-                        placeholder="搜索颜色编码或配方"
-                        clearable
-                        @input="handleSearch"
-                    >
-                        <template #prefix>
-                            <i class="el-icon-search"></i>
-                        </template>
-                    </el-input>
-                </div>
-                <div class="stats-row">
-                    显示 {{ filteredColors.length }} / {{ colors.length }} 个颜色
-                </div>
-            </div>
-            
-            <div class="color-list-container">
-                <div class="view-toggle">
-                    <el-radio-group v-model="viewMode" size="small">
-                        <el-radio-button label="grid">网格</el-radio-button>
-                        <el-radio-button label="list">列表</el-radio-button>
-                        <el-radio-button label="compact">紧凑</el-radio-button>
-                    </el-radio-group>
-                </div>
-                
-                <!-- Grid View -->
-                <div v-if="viewMode === 'grid'" class="color-grid">
-                    <div 
-                        v-for="color in paginatedColors"
-                        :key="color.id"
-                        class="color-grid-item"
-                        :class="{ 
-                            'selected': selectedColor && selectedColor.id === color.id,
-                            'has-rgb': color.hasValidRGB 
-                        }"
-                        @click="handleSelect(color)"
-                        @mouseenter="handleHover(color)"
-                        @mouseleave="handleHoverEnd"
-                    >
-                        <div class="color-preview" :style="{ backgroundColor: color.hex || getCategoryColor(color) }">
-                            <div v-if="!color.hasValidRGB" class="no-rgb-indicator">?</div>
-                        </div>
-                        <div class="color-label">{{ color.color_code }}</div>
-                        <div class="color-hsl" v-if="color.hsl">
-                            H:{{ Math.round(color.hsl.h) }}° S:{{ Math.round(color.hsl.s) }}%
-                        </div>
-                    </div>
-                </div>
-                
-                <!-- List View -->
-                <div v-else-if="viewMode === 'list'" class="color-list">
-                    <div 
-                        v-for="color in paginatedColors"
-                        :key="color.id"
-                        class="color-list-item"
-                        :class="{ 'selected': selectedColor && selectedColor.id === color.id }"
-                        @click="handleSelect(color)"
-                        @mouseenter="handleHover(color)"
-                        @mouseleave="handleHoverEnd"
-                    >
-                        <div class="color-swatch" :style="{ backgroundColor: color.hex || getCategoryColor(color) }"></div>
-                        <div class="color-info">
-                            <div class="color-header">
-                                <span class="color-code">{{ color.color_code }}</span>
-                                <span class="color-category">{{ getCategoryName(color.category_id) }}</span>
-                            </div>
-                            <div class="color-formula">{{ color.formula }}</div>
-                            <div class="color-values" v-if="color.hasValidRGB">
-                                <span v-if="color.rgb">RGB: {{ color.rgb.r }}, {{ color.rgb.g }}, {{ color.rgb.b }}</span>
-                                <span v-if="color.hsl">HSL: {{ Math.round(color.hsl.h) }}°, {{ Math.round(color.hsl.s) }}%, {{ Math.round(color.hsl.l) }}%</span>
-                            </div>
-                        </div>
-                        <div class="color-wheel-position" v-if="color.hsl">
-                            <svg width="30" height="30" viewBox="0 0 30 30">
-                                <circle cx="15" cy="15" r="14" fill="none" stroke="#ddd" stroke-width="1"/>
-                                <circle 
-                                    :cx="15 + 12 * Math.cos(color.hsl.h * Math.PI / 180) * (color.hsl.s / 100)"
-                                    :cy="15 + 12 * Math.sin(color.hsl.h * Math.PI / 180) * (color.hsl.s / 100)"
-                                    r="3" 
-                                    :fill="color.hex || '#888'"
-                                />
-                            </svg>
-                        </div>
-                    </div>
-                </div>
-                
-                <!-- Compact View -->
-                <div v-else class="color-compact">
-                    <span 
-                        v-for="color in paginatedColors"
-                        :key="color.id"
-                        class="color-chip"
-                        :class="{ 'selected': selectedColor && selectedColor.id === color.id }"
-                        :style="{ backgroundColor: color.hex || getCategoryColor(color) }"
-                        :title="color.color_code + ' - ' + color.formula"
-                        @click="handleSelect(color)"
-                        @mouseenter="handleHover(color)"
-                        @mouseleave="handleHoverEnd"
-                    >
-                        {{ color.color_code }}
-                    </span>
-                </div>
-            </div>
-            
-            <!-- Pagination -->
-            <div class="pagination-controls" v-if="totalPages > 1">
-                <el-pagination
-                    v-model:current-page="currentPage"
-                    :page-size="pageSize"
-                    :total="filteredColors.length"
-                    :page-sizes="[20, 50, 100, 200]"
-                    layout="total, sizes, prev, pager, next"
-                    @size-change="handleSizeChange"
-                    @current-change="handlePageChange"
-                />
-            </div>
-        </div>
-    `,
-    props: {
-        colors: Array,
-        selectedColor: Object,
-        categories: Array
-    },
-    data() {
-        return {
-            sortBy: 'hue',
-            filterCategory: null,
-            showOnlyWithRGB: false,
-            searchTerm: '',
-            viewMode: 'grid',
-            currentPage: 1,
-            pageSize: 50,
-            hoveredColor: null
-        };
-    },
-    computed: {
-        filteredColors() {
-            let filtered = this.colors;
-            
-            // Category filter
-            if (this.filterCategory) {
-                filtered = filtered.filter(c => c.category_id === this.filterCategory);
-            }
-            
-            // RGB filter
-            if (this.showOnlyWithRGB) {
-                filtered = filtered.filter(c => c.hasValidRGB);
-            }
-            
-            // Search filter
-            if (this.searchTerm) {
-                const term = this.searchTerm.toLowerCase();
-                filtered = filtered.filter(c => 
-                    c.color_code.toLowerCase().includes(term) ||
-                    c.formula.toLowerCase().includes(term) ||
-                    (c.name && c.name.toLowerCase().includes(term))
-                );
-            }
-            
-            // Sorting
-            return filtered.sort((a, b) => {
-                switch(this.sortBy) {
-                    case 'hue':
-                        return (a.hsl?.h || 360) - (b.hsl?.h || 360);
-                    case 'lightness':
-                        return (a.hsl?.l || 0) - (b.hsl?.l || 0);
-                    case 'saturation':
-                        return (a.hsl?.s || 0) - (b.hsl?.s || 0);
-                    case 'name':
-                        return (a.color_code || '').localeCompare(b.color_code || '');
-                    case 'date':
-                        return new Date(b.updated_at || 0) - new Date(a.updated_at || 0);
-                    default:
-                        return 0;
-                }
-            });
-        },
-        
-        paginatedColors() {
-            const start = (this.currentPage - 1) * this.pageSize;
-            const end = start + this.pageSize;
-            return this.filteredColors.slice(start, end);
-        },
-        
-        totalPages() {
-            return Math.ceil(this.filteredColors.length / this.pageSize);
-        }
-    },
-    
-    watch: {
-        selectedColor(newVal) {
-            // Auto-scroll to selected color
-            if (newVal) {
-                const index = this.filteredColors.findIndex(c => c.id === newVal.id);
-                if (index >= 0) {
-                    const page = Math.floor(index / this.pageSize) + 1;
-                    if (page !== this.currentPage) {
-                        this.currentPage = page;
-                    }
-                }
-            }
-        }
-    },
-    
-    methods: {
-        handleSelect(color) {
-            this.$emit('select', color);
-        },
-        
-        handleHover(color) {
-            this.hoveredColor = color;
-            this.$emit('hover', color);
-        },
-        
-        handleHoverEnd() {
-            this.hoveredColor = null;
-        },
-        
-        handleSortChange() {
-            this.currentPage = 1;
-        },
-        
-        handleFilterChange() {
-            this.currentPage = 1;
-        },
-        
-        handleSearch() {
-            this.currentPage = 1;
-        },
-        
-        handlePageChange(page) {
-            this.currentPage = page;
-        },
-        
-        handleSizeChange(size) {
-            this.pageSize = size;
-            this.currentPage = 1;
-        },
-        
-        getCategoryColor(color) {
-            const categoryColors = {
-                1: '#4A90E2', // 蓝色系
-                2: '#F5D547', // 黄色系
-                3: '#E85D75', // 红色系
-                4: '#7FBA40', // 绿色系
-                5: '#9B59B6', // 紫色系
-                6: '#FF6B6B', // 色精
-                7: '#95A5A6'  // 其他
-            };
-            return categoryColors[color.category_id] || '#CCCCCC';
-        },
-        
-        getCategoryName(categoryId) {
-            const category = this.categories.find(c => c.id === categoryId);
-            return category ? category.name : '';
-        }
-    }
-};
+if (dictionaryViews.WheelDictionaryView) {
+    paletteComponents['color-wheel-view'] = dictionaryViews.WheelDictionaryView;
+} else {
+    paletteDebug('Wheel view module unavailable for palette dialog');
+}
 
-// Register child components to ColorPaletteDialog
-ColorPaletteDialog.components = {
-    'hsl-color-space-view': HslColorSpaceView,
-    'color-wheel-view': ColorWheelView,
-    'enhanced-list-view': EnhancedListView
-};
+if (dictionaryViews.SimplifiedListView) {
+    paletteComponents['enhanced-list-view'] = dictionaryViews.SimplifiedListView;
+} else {
+    paletteDebug('List view module unavailable for palette dialog');
+}
+
+ColorPaletteDialog.components = paletteComponents;

--- a/frontend/js/utils/color-processing.js
+++ b/frontend/js/utils/color-processing.js
@@ -1,0 +1,183 @@
+(function(window) {
+    'use strict';
+
+    const ColorDictionaryHelpers = window.ColorDictionaryHelpers || {};
+
+    const DEFAULT_CATEGORY_COLORS = {
+        1: { r: 70, g: 130, b: 180 },  // 蓝 - Blue
+        2: { r: 255, g: 215, b: 0 },   // 黄 - Yellow
+        3: { r: 220, g: 20, b: 60 },   // 红 - Red
+        4: { r: 34, g: 139, b: 34 },   // 绿 - Green
+        5: { r: 128, g: 0, b: 128 },   // 紫 - Purple
+        6: { r: 139, g: 69, b: 19 },   // 色精 - Brown
+        7: { r: 255, g: 140, b: 0 }    // 其他 - Orange
+    };
+
+    function normalizeHexValue(value) {
+        if (!value || value === '未填写') return '';
+        const trimmed = String(value).trim();
+        if (!trimmed) return '';
+        return trimmed.startsWith('#') ? trimmed.toUpperCase() : `#${trimmed.toUpperCase()}`;
+    }
+
+    function ensureRgb(color, options) {
+        const normalized = normalizeHexValue(color.hex_color || color.hex);
+        if (normalized) {
+            const rgb = typeof hexToRgb === 'function' ? hexToRgb(normalized) : null;
+            if (rgb) {
+                return { rgb, hex: normalized, hasValidRGB: true };
+            }
+        }
+
+        const components = [color.rgb_r, color.rgb_g, color.rgb_b]
+            .map((value) => (value !== undefined && value !== null ? parseInt(value, 10) : null));
+        if (components.every((value) => Number.isFinite(value))) {
+            const [r, g, b] = components;
+            const hex = typeof rgbToHex === 'function' ? rgbToHex(r, g, b) : null;
+            return {
+                rgb: { r, g, b },
+                hex: hex || normalized || null,
+                hasValidRGB: true
+            };
+        }
+
+        if (options && options.fallbackByCategory) {
+            const fallback = options.fallbackByCategory(color.category_id);
+            if (fallback) {
+                const hex = typeof rgbToHex === 'function'
+                    ? rgbToHex(fallback.r, fallback.g, fallback.b)
+                    : null;
+                return {
+                    rgb: fallback,
+                    hex,
+                    hasValidRGB: false
+                };
+            }
+        }
+
+        return {
+            rgb: null,
+            hex: normalized || null,
+            hasValidRGB: false
+        };
+    }
+
+    function ensureLab(rgb) {
+        if (!rgb) return null;
+        if (typeof rgbToLab === 'function') {
+            return rgbToLab(rgb.r, rgb.g, rgb.b);
+        }
+        return null;
+    }
+
+    function enrichColor(color, index, options = {}) {
+        const enriched = { ...color };
+
+        const { rgb, hex, hasValidRGB } = ensureRgb(color, options);
+        if (rgb) {
+            enriched.rgb = rgb;
+        }
+        if (hex) {
+            enriched.hex = hex;
+        }
+        enriched.hasValidRGB = Boolean(hasValidRGB);
+
+        if (rgb && typeof rgbToHsl === 'function') {
+            enriched.hsl = rgbToHsl(rgb.r, rgb.g, rgb.b);
+        } else if (!enriched.hsl && options.defaultHsl) {
+            enriched.hsl = { ...options.defaultHsl };
+        }
+
+        if (rgb) {
+            enriched.lab = ensureLab(rgb);
+        }
+
+        if (!enriched.name) {
+            enriched.name = color.color_code || color.color_name || `Color ${index + 1}`;
+        }
+
+        return enriched;
+    }
+
+    function enrichColors(colors, options = {}) {
+        if (!Array.isArray(colors)) return [];
+        const fallback = options.fallbackByCategory || ((categoryId) => DEFAULT_CATEGORY_COLORS[categoryId] || { r: 128, g: 128, b: 128 });
+
+        return colors.map((color, index) => {
+            return enrichColor(color, index, {
+                fallbackByCategory: fallback,
+                defaultHsl: options.defaultHsl
+            });
+        });
+    }
+
+    function ensureLabFromColor(color) {
+        if (!color) return null;
+        if (color.lab) return color.lab;
+        if (color.rgb) return ensureLab(color.rgb);
+        if (color.rgb_r != null && color.rgb_g != null && color.rgb_b != null) {
+            return ensureLab({
+                r: Number(color.rgb_r),
+                g: Number(color.rgb_g),
+                b: Number(color.rgb_b)
+            });
+        }
+        const style = ColorDictionaryHelpers.getColorStyle
+            ? ColorDictionaryHelpers.getColorStyle(color)
+            : null;
+        if (style && typeof window.parseColorString === 'function') {
+            const parsed = window.parseColorString(style);
+            if (parsed && parsed.rgb) {
+                return ensureLab(parsed.rgb);
+            }
+        }
+        return null;
+    }
+
+    function calculateDeltaE(color1, color2, options = {}) {
+        if (!color1 || !color2) return Number.POSITIVE_INFINITY;
+
+        const lab1 = ensureLabFromColor(color1);
+        const lab2 = ensureLabFromColor(color2);
+        const algorithm = (options && options.algorithm) || '2000';
+
+        if (lab1 && lab2) {
+            if (algorithm === '94' && typeof window.deltaE94 === 'function') {
+                return window.deltaE94(lab1, lab2, options.weights);
+            }
+            if (algorithm === '76' && typeof window.deltaE76 === 'function') {
+                return window.deltaE76(lab1, lab2);
+            }
+            if (typeof window.deltaE2000 === 'function') {
+                return window.deltaE2000(lab1, lab2, options.weights);
+            }
+            if (typeof window.deltaE94 === 'function') {
+                return window.deltaE94(lab1, lab2, options.weights);
+            }
+            if (typeof window.deltaE76 === 'function') {
+                return window.deltaE76(lab1, lab2);
+            }
+        }
+
+        const rgb1 = color1.rgb || (color1.rgb_r != null ? { r: Number(color1.rgb_r), g: Number(color1.rgb_g), b: Number(color1.rgb_b) } : null);
+        const rgb2 = color2.rgb || (color2.rgb_r != null ? { r: Number(color2.rgb_r), g: Number(color2.rgb_g), b: Number(color2.rgb_b) } : null);
+        if (rgb1 && rgb2) {
+            const dr = rgb1.r - rgb2.r;
+            const dg = rgb1.g - rgb2.g;
+            const db = rgb1.b - rgb2.b;
+            return Math.sqrt(dr * dr + dg * dg + db * db) * 0.4;
+        }
+
+        return Number.POSITIVE_INFINITY;
+    }
+
+    function getDefaultColorForCategory(categoryId) {
+        return DEFAULT_CATEGORY_COLORS[categoryId] || { r: 128, g: 128, b: 128 };
+    }
+
+    window.ColorProcessingUtils = {
+        enrichColors,
+        calculateDeltaE,
+        getDefaultColorForCategory
+    };
+})(window);

--- a/test-color-palette.html
+++ b/test-color-palette.html
@@ -18,6 +18,11 @@
     <!-- Our utilities and components -->
     <script src="frontend/js/utils/color-tools.js"></script>
     <script src="frontend/js/utils/colorDistance.js"></script>
+    <script src="frontend/js/components/color-dictionary/helpers.js"></script>
+    <script src="frontend/js/utils/color-processing.js"></script>
+    <script src="frontend/js/components/color-dictionary/views/list-view.js"></script>
+    <script src="frontend/js/components/color-dictionary/views/hsl-view.js"></script>
+    <script src="frontend/js/components/color-dictionary/views/wheel-view.js"></script>
     <script src="frontend/js/components/color-palette-dialog.js"></script>
     
     <!-- Styles -->


### PR DESCRIPTION
## Summary
- add a shared ColorProcessingUtils helper for color enrichment and delta-E comparisons
- rewire the palette dialog to use the modular dictionary views with palette-specific props
- extend the dictionary HSL, wheel, and list views plus bootstrap HTML to support the shared usage

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca59b5bc308321bab1899b8edb61f2