### PR TITLE
Refactor app data and search into composables

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -162,7 +162,7 @@
     
     <!-- 主应用入口 - 必须最后加载 -->
     <!-- 创建Vue应用实例，注册组件，挂载到#app -->
-    <script src="js/app.js"></script>
+    <script type="module" src="js/app.js"></script>
     <script>
         // 永久显示返回顶部按钮，仅处理点击滚动
         (function(){

--- a/frontend/js/modules/app-data.js
+++ b/frontend/js/modules/app-data.js
@@ -1,0 +1,193 @@
+const { ref, reactive } = Vue;
+
+const DEFAULT_CONFIG = {
+    mode: 'production',
+    testModeItemsPerPage: 3,
+    features: {}
+};
+
+export function useAppData(options = {}) {
+    const registerDataset = typeof options.registerDataset === 'function' ? options.registerDataset : () => {};
+    const baseURL = ref(options.baseURL || window.location.origin);
+    const loading = ref(false);
+    const appConfig = reactive({ ...DEFAULT_CONFIG });
+    const categories = ref([]);
+    const customColors = ref([]);
+    const artworks = ref([]);
+    const montMarteColors = ref([]);
+    const suppliers = ref([]);
+    const purchaseLinks = ref([]);
+
+    let colorFormulaIndex = null;
+
+    function broadcast(eventName, payload) {
+        try {
+            window.dispatchEvent(new CustomEvent(eventName, { detail: payload }));
+        } catch (e) {
+            // Ignore broadcasting failures to keep data loading resilient
+        }
+    }
+
+    async function loadAppConfig() {
+        try {
+            const response = await fetch(`${baseURL.value}/api/config`);
+            if (!response.ok) throw new Error('Failed to fetch config');
+            const config = await response.json();
+            Object.assign(appConfig, config || {});
+        } catch (error) {
+            console.warn('Failed to load app config, using defaults:', error);
+        }
+    }
+
+    function buildColorFormulaIndex() {
+        colorFormulaIndex = {};
+        (customColors.value || []).forEach(color => {
+            colorFormulaIndex[color.color_code] = color.formula || '';
+        });
+    }
+
+    function syncFormulasIfChanged() {
+        if (!window.$formulaCalc || !colorFormulaIndex) return;
+        (customColors.value || []).forEach(color => {
+            const code = color.color_code;
+            const newFormula = color.formula || '';
+            const oldFormula = colorFormulaIndex[code];
+            if (oldFormula !== newFormula) {
+                window.$formulaCalc.syncFormulaChange(code, newFormula);
+            }
+        });
+        buildColorFormulaIndex();
+    }
+
+    async function loadCategories() {
+        try {
+            const res = await window.api.categories.getAll();
+            categories.value = res.data;
+            broadcast('categories-updated', categories.value);
+        } catch (e) {
+            console.warn('[app-data] Failed to load categories', e);
+        }
+    }
+
+    async function loadCustomColors(bypassCache = false) {
+        try {
+            const res = await window.api.customColors.getAll({ bypassCache });
+            customColors.value = res.data;
+            registerDataset('customColors', customColors.value.map(color => ({
+                id: color.id,
+                code: color.color_code || color.code || '',
+                name: color.name || ''
+            })));
+            if (colorFormulaIndex) {
+                syncFormulasIfChanged();
+            } else {
+                buildColorFormulaIndex();
+            }
+            broadcast('colors-updated', customColors.value);
+        } catch (e) {
+            console.warn('[app-data] Failed to load custom colors', e);
+        }
+    }
+
+    async function loadArtworks() {
+        try {
+            const res = await window.api.artworks.getAll();
+            artworks.value = res.data;
+            const artworksIndex = [];
+            const schemesIndex = [];
+            artworks.value.forEach(artwork => {
+                const name = artwork.name || artwork.title || '';
+                const code = artwork.code || artwork.no || '';
+                artworksIndex.push({ id: artwork.id, name, code });
+                if (Array.isArray(artwork.schemes)) {
+                    artwork.schemes.forEach(scheme => {
+                        schemesIndex.push({
+                            id: scheme.id,
+                            artworkId: artwork.id,
+                            artworkName: name,
+                            artworkCode: code,
+                            name: scheme.name || ''
+                        });
+                    });
+                }
+            });
+            registerDataset('artworks', artworksIndex);
+            registerDataset('schemes', schemesIndex);
+        } catch (e) {
+            console.warn('[app-data] Failed to load artworks', e);
+        }
+    }
+
+    async function loadMontMarteColors() {
+        try {
+            const res = await window.api.montMarteColors.getAll();
+            montMarteColors.value = res.data;
+            registerDataset('rawMaterials', montMarteColors.value.map(material => ({
+                id: material.id,
+                name: material.name
+            })));
+        } catch (e) {
+            console.warn('[app-data] Failed to load raw materials', e);
+        }
+    }
+
+    async function loadSuppliers() {
+        try {
+            const response = await axios.get(`${baseURL.value}/api/suppliers`);
+            suppliers.value = response.data || [];
+        } catch (e) {
+            console.warn('[app-data] Failed to load suppliers', e);
+        }
+    }
+
+    async function loadPurchaseLinks() {
+        try {
+            const response = await axios.get(`${baseURL.value}/api/purchase-links`);
+            purchaseLinks.value = response.data || [];
+        } catch (e) {
+            console.warn('[app-data] Failed to load purchase links', e);
+        }
+    }
+
+    async function initApp() {
+        loading.value = true;
+        try {
+            await loadAppConfig();
+            await Promise.all([
+                loadCategories(),
+                loadCustomColors(),
+                loadArtworks(),
+                loadMontMarteColors(),
+                loadSuppliers(),
+                loadPurchaseLinks()
+            ]);
+            if (!colorFormulaIndex) {
+                buildColorFormulaIndex();
+            }
+        } catch (e) {
+            console.warn('[app-data] Failed to initialise app', e);
+        } finally {
+            loading.value = false;
+        }
+    }
+
+    return {
+        baseURL,
+        loading,
+        appConfig,
+        categories,
+        customColors,
+        artworks,
+        montMarteColors,
+        suppliers,
+        purchaseLinks,
+        initApp,
+        loadAppConfig,
+        loadCategories,
+        loadCustomColors,
+        loadArtworks,
+        loadMontMarteColors,
+        loadSuppliers,
+        loadPurchaseLinks
+    };
+}

--- a/frontend/js/modules/global-search.js
+++ b/frontend/js/modules/global-search.js
@@ -1,0 +1,177 @@
+const { ref, reactive } = Vue;
+
+export function useGlobalSearch() {
+    const globalSearchQuery = ref('');
+    const globalSearchResults = ref([]);
+    const showSearchDropdown = ref(false);
+    const searchIndex = reactive({
+        customColors: [],
+        artworks: [],
+        schemes: [],
+        rawMaterials: []
+    });
+    const indexReady = reactive({
+        customColors: false,
+        artworks: false,
+        rawMaterials: false
+    });
+    let searchDebounceTimer = null;
+
+    function registerDataset(type, items) {
+        if (!type || !Array.isArray(items)) return;
+        if (type === 'customColors') {
+            searchIndex.customColors = items.slice();
+            indexReady.customColors = true;
+        } else if (type === 'artworks') {
+            searchIndex.artworks = items.slice();
+            indexReady.artworks = true;
+        } else if (type === 'schemes') {
+            searchIndex.schemes = items.slice();
+        } else if (type === 'rawMaterials') {
+            searchIndex.rawMaterials = items.slice();
+            indexReady.rawMaterials = true;
+        }
+    }
+
+    function openSearchDropdown() {
+        showSearchDropdown.value = true;
+    }
+
+    function closeSearchDropdown() {
+        showSearchDropdown.value = false;
+    }
+
+    function buildSearchResults() {
+        const qRaw = (globalSearchQuery.value || '').trim();
+        if (!qRaw) {
+            globalSearchResults.value = [];
+            showSearchDropdown.value = false;
+            searchDebounceTimer = null;
+            return;
+        }
+        const qLower = qRaw.toLowerCase();
+        const tokens = qLower.split(/\s+/).filter(Boolean);
+        const multi = tokens.length > 1;
+        const results = [];
+        const push = item => results.push(item);
+
+        searchIndex.customColors.forEach(color => {
+            const code = (color.code || '').toLowerCase();
+            const name = (color.name || '').toLowerCase();
+            const haystack = [code, name];
+            const match = multi
+                ? tokens.every(token => haystack.some(hay => hay && hay.includes(token)))
+                : haystack.some(hay => hay && hay.includes(qLower));
+            if (match) {
+                push({
+                    type: 'customColor',
+                    id: color.id,
+                    code: color.code,
+                    display: color.code || color.name,
+                    group: '自配色',
+                    pathLabel: `自配色管理 -> ${(color.code || '')}${color.name ? ' ' + color.name : ''}`
+                });
+            }
+        });
+
+        const artworkMatches = [];
+        const schemeMatches = [];
+
+        searchIndex.artworks.forEach(artwork => {
+            const name = (artwork.name || '').toLowerCase();
+            const code = (artwork.code || '').toLowerCase();
+            const combo = code && name ? `${code}-${name}` : (code || name);
+            const haystack = [name, code, combo];
+            const match = multi
+                ? tokens.every(token => haystack.some(hay => hay && hay.includes(token)))
+                : haystack.some(hay => hay && hay.includes(qLower));
+            if (match) {
+                artworkMatches.push({
+                    type: 'artwork',
+                    id: artwork.id,
+                    display: (artwork.code ? `${artwork.code}-` : '') + (artwork.name || ''),
+                    group: '作品',
+                    pathLabel: `作品配色管理 -> ${(artwork.code ? `${artwork.code}-` : '') + (artwork.name || '')}`
+                });
+            }
+        });
+
+        searchIndex.schemes.forEach(scheme => {
+            const schemeName = (scheme.name || '').toLowerCase();
+            const artworkName = (scheme.artworkName || '').toLowerCase();
+            const artworkCode = (scheme.artworkCode || '').toLowerCase();
+            const combo = artworkCode && artworkName ? `${artworkCode}-${artworkName}` : (artworkCode || artworkName);
+            const haystack = [schemeName, artworkName, artworkCode, combo];
+            const match = multi
+                ? tokens.every(token => haystack.some(hay => hay && hay.includes(token)))
+                : haystack.some(hay => hay && hay.includes(qLower));
+            if (match) {
+                schemeMatches.push({
+                    type: 'scheme',
+                    id: scheme.id,
+                    parentId: scheme.artworkId,
+                    artworkName: scheme.artworkName,
+                    artworkCode: scheme.artworkCode,
+                    display: scheme.name,
+                    group: '配色方案',
+                    pathLabel: `作品配色管理 -> ${(scheme.artworkCode ? `${scheme.artworkCode}-` : '') + scheme.artworkName}-[${scheme.name}]`
+                });
+            }
+        });
+
+        if (multi && schemeMatches.length) {
+            results.push(...schemeMatches);
+        } else {
+            results.push(...artworkMatches, ...schemeMatches);
+        }
+
+        searchIndex.rawMaterials.forEach(material => {
+            const name = (material.name || '').toLowerCase();
+            const match = multi
+                ? tokens.every(token => name && name.includes(token))
+                : (name && name.includes(qLower));
+            if (match) {
+                push({
+                    type: 'rawMaterial',
+                    id: material.id,
+                    display: material.name,
+                    group: '原料',
+                    pathLabel: `颜色原料管理 -> ${material.name}`
+                });
+            }
+        });
+
+        const groupOrder = { '自配色': 1, '作品': 2, '配色方案': 3, '原料': 4 };
+        results.sort((a, b) => {
+            const ga = groupOrder[a.group] || 99;
+            const gb = groupOrder[b.group] || 99;
+            if (ga !== gb) return ga - gb;
+            return (a.display || '').localeCompare(b.display || '', 'zh-CN');
+        });
+
+        const limited = results.slice(0, 60);
+        globalSearchResults.value = limited;
+        showSearchDropdown.value = !!limited.length;
+        searchDebounceTimer = null;
+    }
+
+    function handleGlobalSearchInput(value) {
+        globalSearchQuery.value = value;
+        if (searchDebounceTimer) clearTimeout(searchDebounceTimer);
+        searchDebounceTimer = setTimeout(() => buildSearchResults(), 200);
+        if (value && !showSearchDropdown.value) showSearchDropdown.value = true;
+        if (!value) globalSearchResults.value = [];
+    }
+
+    return {
+        globalSearchQuery,
+        globalSearchResults,
+        showSearchDropdown,
+        indexReady,
+        registerDataset,
+        handleGlobalSearchInput,
+        openSearchDropdown,
+        closeSearchDropdown,
+        buildSearchResults
+    };
+}


### PR DESCRIPTION
## Summary
- extract the root data-loading responsibilities into a `useAppData` composable that keeps dataset updates and formula sync logic together
- move global search state and helpers into a `useGlobalSearch` composable and refactor the Vue root component to consume both composables via the Composition API
- update the application entry script to run as an ES module so the new helpers can be imported cleanly

## Testing
- Not run (manual browser verification recommended)


------
https://chatgpt.com/codex/tasks/task_e_68cd17d8d3c8832196b3e095c341ed28